### PR TITLE
Year 2017

### DIFF
--- a/AddressBookPlugIns/AKAddressBookPhonePlugIn.h
+++ b/AddressBookPlugIns/AKAddressBookPhonePlugIn.h
@@ -2,8 +2,8 @@
 //  AKAddressBookPhonePlugIn.h
 //  AKAddressBookPhonePlugIn
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookPhonePlugIn.h
+++ b/AddressBookPlugIns/AKAddressBookPhonePlugIn.h
@@ -3,7 +3,7 @@
 //  AKAddressBookPhonePlugIn
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookPhonePlugIn.m
+++ b/AddressBookPlugIns/AKAddressBookPhonePlugIn.m
@@ -2,8 +2,8 @@
 //  AKAddressBookPhonePlugIn.m
 //  AKAddressBookPhonePlugIn
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookPhonePlugIn.m
+++ b/AddressBookPlugIns/AKAddressBookPhonePlugIn.m
@@ -3,7 +3,7 @@
 //  AKAddressBookPhonePlugIn
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.h
+++ b/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.h
@@ -3,7 +3,7 @@
 //  AKAddressBookSIPAddressPlugIn
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.h
+++ b/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.h
@@ -2,8 +2,8 @@
 //  AKAddressBookSIPAddressPlugIn.h
 //  AKAddressBookSIPAddressPlugIn
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.m
+++ b/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.m
@@ -2,8 +2,8 @@
 //  AKAddressBookSIPAddressPlugIn.m
 //  AKAddressBookSIPAddressPlugIn
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.m
+++ b/AddressBookPlugIns/AKAddressBookSIPAddressPlugIn.m
@@ -3,7 +3,7 @@
 //  AKAddressBookSIPAddressPlugIn
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FallingBackSoundIO.swift
+++ b/Domain/FallingBackSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FallingBackSoundIO.swift
+++ b/Domain/FallingBackSoundIO.swift
@@ -2,8 +2,8 @@
 //  FallingBackSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FirstBuiltInSystemSoundIO.swift
+++ b/Domain/FirstBuiltInSystemSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FirstBuiltInSystemSoundIO.swift
+++ b/Domain/FirstBuiltInSystemSoundIO.swift
@@ -2,8 +2,8 @@
 //  FirstBuiltInSystemSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FirstSystemAudioDevice.swift
+++ b/Domain/FirstSystemAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FirstSystemAudioDevice.swift
+++ b/Domain/FirstSystemAudioDevice.swift
@@ -2,8 +2,8 @@
 //  FirstSystemAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FirstSystemSoundIO.swift
+++ b/Domain/FirstSystemSoundIO.swift
@@ -2,8 +2,8 @@
 //  FirstSystemSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/FirstSystemSoundIO.swift
+++ b/Domain/FirstSystemSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/NullSystemAudioDevice.swift
+++ b/Domain/NullSystemAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/NullSystemAudioDevice.swift
+++ b/Domain/NullSystemAudioDevice.swift
@@ -2,8 +2,8 @@
 //  NullSystemAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/NullUserAgentAudioDevice.swift
+++ b/Domain/NullUserAgentAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/NullUserAgentAudioDevice.swift
+++ b/Domain/NullUserAgentAudioDevice.swift
@@ -2,8 +2,8 @@
 //  NullUserAgentAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/PreferredSoundIO.swift
+++ b/Domain/PreferredSoundIO.swift
@@ -2,8 +2,8 @@
 //  PreferredSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/PreferredSoundIO.swift
+++ b/Domain/PreferredSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SimpleSoundIO.swift
+++ b/Domain/SimpleSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SimpleSoundIO.swift
+++ b/Domain/SimpleSoundIO.swift
@@ -2,8 +2,8 @@
 //  SimpleSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SimpleSystemAudioDevice.swift
+++ b/Domain/SimpleSystemAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SimpleSystemAudioDevice.swift
+++ b/Domain/SimpleSystemAudioDevice.swift
@@ -2,8 +2,8 @@
 //  SimpleSystemAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SimpleUserAgentAudioDevice.swift
+++ b/Domain/SimpleUserAgentAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SimpleUserAgentAudioDevice.swift
+++ b/Domain/SimpleUserAgentAudioDevice.swift
@@ -2,8 +2,8 @@
 //  SimpleUserAgentAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SoundIO.swift
+++ b/Domain/SoundIO.swift
@@ -2,8 +2,8 @@
 //  SoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SoundIO.swift
+++ b/Domain/SoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemAudioDevice.swift
+++ b/Domain/SystemAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemAudioDevice.swift
+++ b/Domain/SystemAudioDevice.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemAudioDevices.swift
+++ b/Domain/SystemAudioDevices.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemAudioDevices.swift
+++ b/Domain/SystemAudioDevices.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevices.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemSoundIO.swift
+++ b/Domain/SystemSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemSoundIO.swift
+++ b/Domain/SystemSoundIO.swift
@@ -2,8 +2,8 @@
 //  SystemSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemToUserAgentAudioDeviceMap.swift
+++ b/Domain/SystemToUserAgentAudioDeviceMap.swift
@@ -2,8 +2,8 @@
 //  SystemToUserAgentAudioDeviceMap.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/SystemToUserAgentAudioDeviceMap.swift
+++ b/Domain/SystemToUserAgentAudioDeviceMap.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/UserAgentAudioDevice.swift
+++ b/Domain/UserAgentAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/UserAgentAudioDevice.swift
+++ b/Domain/UserAgentAudioDevice.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/UserAgentAudioDeviceNameToDeviceMap.swift
+++ b/Domain/UserAgentAudioDeviceNameToDeviceMap.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDeviceNameToDeviceMap.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Domain/UserAgentAudioDeviceNameToDeviceMap.swift
+++ b/Domain/UserAgentAudioDeviceNameToDeviceMap.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/SimpleSystemSoundIO.swift
+++ b/DomainTestDoubles/SimpleSystemSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/SimpleSystemSoundIO.swift
+++ b/DomainTestDoubles/SimpleSystemSoundIO.swift
@@ -2,8 +2,8 @@
 //  SimpleSystemSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/SystemAudioDevice+Equality.swift
+++ b/DomainTestDoubles/SystemAudioDevice+Equality.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevice+Equality.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/SystemAudioDevice+Equality.swift
+++ b/DomainTestDoubles/SystemAudioDevice+Equality.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/SystemAudioDeviceTestFactory.swift
+++ b/DomainTestDoubles/SystemAudioDeviceTestFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/SystemAudioDeviceTestFactory.swift
+++ b/DomainTestDoubles/SystemAudioDeviceTestFactory.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDeviceTestFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/UserAgentAudioDevice+Equality.swift
+++ b/DomainTestDoubles/UserAgentAudioDevice+Equality.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevice+Equality.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTestDoubles/UserAgentAudioDevice+Equality.swift
+++ b/DomainTestDoubles/UserAgentAudioDevice+Equality.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FallingBackSoundIOTests.swift
+++ b/DomainTests/FallingBackSoundIOTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FallingBackSoundIOTests.swift
+++ b/DomainTests/FallingBackSoundIOTests.swift
@@ -2,8 +2,8 @@
 //  FallingBackSoundIOTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FirstBuiltInSystemSoundIOTests.swift
+++ b/DomainTests/FirstBuiltInSystemSoundIOTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FirstBuiltInSystemSoundIOTests.swift
+++ b/DomainTests/FirstBuiltInSystemSoundIOTests.swift
@@ -2,8 +2,8 @@
 //  FirstBuiltInSystemSoundIOTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FirstSystemAudioDeviceTests.swift
+++ b/DomainTests/FirstSystemAudioDeviceTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FirstSystemAudioDeviceTests.swift
+++ b/DomainTests/FirstSystemAudioDeviceTests.swift
@@ -2,8 +2,8 @@
 //  FirstSystemAudioDeviceTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FirstSystemSoundIOTests.swift
+++ b/DomainTests/FirstSystemSoundIOTests.swift
@@ -2,8 +2,8 @@
 //  FirstSystemSoundIOTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/FirstSystemSoundIOTests.swift
+++ b/DomainTests/FirstSystemSoundIOTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/PreferredSoundIOTests.swift
+++ b/DomainTests/PreferredSoundIOTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/PreferredSoundIOTests.swift
+++ b/DomainTests/PreferredSoundIOTests.swift
@@ -2,8 +2,8 @@
 //  PreferredSoundIOTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/SimpleSoundIOTests.swift
+++ b/DomainTests/SimpleSoundIOTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/SimpleSoundIOTests.swift
+++ b/DomainTests/SimpleSoundIOTests.swift
@@ -2,8 +2,8 @@
 //  SimpleSoundIOTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/SystemAudioDevicesTests.swift
+++ b/DomainTests/SystemAudioDevicesTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/SystemAudioDevicesTests.swift
+++ b/DomainTests/SystemAudioDevicesTests.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevicesTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/SystemToUserAgentAudioDeviceMapTests.swift
+++ b/DomainTests/SystemToUserAgentAudioDeviceMapTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/SystemToUserAgentAudioDeviceMapTests.swift
+++ b/DomainTests/SystemToUserAgentAudioDeviceMapTests.swift
@@ -2,8 +2,8 @@
 //  SystemToUserAgentAudioDeviceMapTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/UserAgentAudioDevice+SystemAudioDevice.swift
+++ b/DomainTests/UserAgentAudioDevice+SystemAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/DomainTests/UserAgentAudioDevice+SystemAudioDevice.swift
+++ b/DomainTests/UserAgentAudioDevice+SystemAudioDevice.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevice+SystemAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1Payload.h
+++ b/ReceiptValidation/ASN1Payload.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1Payload.h
+++ b/ReceiptValidation/ASN1Payload.h
@@ -2,8 +2,8 @@
 //  ASN1Payload.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1Payload.m
+++ b/ReceiptValidation/ASN1Payload.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1Payload.m
+++ b/ReceiptValidation/ASN1Payload.m
@@ -2,8 +2,8 @@
 //  ASN1Payload.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1PayloadAttribute.swift
+++ b/ReceiptValidation/ASN1PayloadAttribute.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1PayloadAttribute.swift
+++ b/ReceiptValidation/ASN1PayloadAttribute.swift
@@ -2,8 +2,8 @@
 //  ASN1PayloadAttribute.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1PurchaseReceipt.swift
+++ b/ReceiptValidation/ASN1PurchaseReceipt.swift
@@ -2,8 +2,8 @@
 //  ASN1PurchaseReceipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1PurchaseReceipt.swift
+++ b/ReceiptValidation/ASN1PurchaseReceipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1PurchaseReceipts.swift
+++ b/ReceiptValidation/ASN1PurchaseReceipts.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ASN1PurchaseReceipts.swift
+++ b/ReceiptValidation/ASN1PurchaseReceipts.swift
@@ -2,8 +2,8 @@
 //  ASN1PurchaseReceipts.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/CertificateFingerprintValidation.swift
+++ b/ReceiptValidation/CertificateFingerprintValidation.swift
@@ -2,8 +2,8 @@
 //  CertificateFingerprintValidation.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/CertificateFingerprintValidation.swift
+++ b/ReceiptValidation/CertificateFingerprintValidation.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/DefaultNSXPCListenerDelegate.swift
+++ b/ReceiptValidation/DefaultNSXPCListenerDelegate.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/DefaultNSXPCListenerDelegate.swift
+++ b/ReceiptValidation/DefaultNSXPCListenerDelegate.swift
@@ -2,8 +2,8 @@
 //  DefaultNSXPCListenerDelegate.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/DeviceGUID.swift
+++ b/ReceiptValidation/DeviceGUID.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/DeviceGUID.swift
+++ b/ReceiptValidation/DeviceGUID.swift
@@ -2,8 +2,8 @@
 //  DeviceGUID.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7Container.h
+++ b/ReceiptValidation/PKCS7Container.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7Container.h
+++ b/ReceiptValidation/PKCS7Container.h
@@ -2,8 +2,8 @@
 //  PKCS7Container.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7Container.m
+++ b/ReceiptValidation/PKCS7Container.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7Container.m
+++ b/ReceiptValidation/PKCS7Container.m
@@ -2,8 +2,8 @@
 //  PKCS7Container.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7ContainerValidation.swift
+++ b/ReceiptValidation/PKCS7ContainerValidation.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7ContainerValidation.swift
+++ b/ReceiptValidation/PKCS7ContainerValidation.swift
@@ -2,8 +2,8 @@
 //  PKCS7ContainerValidation.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7SignatureValidation.swift
+++ b/ReceiptValidation/PKCS7SignatureValidation.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PKCS7SignatureValidation.swift
+++ b/ReceiptValidation/PKCS7SignatureValidation.swift
@@ -2,8 +2,8 @@
 //  PKCS7SignatureValidation.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PurchaseReceiptAttributesValidation.swift
+++ b/ReceiptValidation/PurchaseReceiptAttributesValidation.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/PurchaseReceiptAttributesValidation.swift
+++ b/ReceiptValidation/PurchaseReceiptAttributesValidation.swift
@@ -2,8 +2,8 @@
 //  PurchaseReceiptAttributesValidation.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ReceiptAttributesValidation.swift
+++ b/ReceiptValidation/ReceiptAttributesValidation.swift
@@ -2,8 +2,8 @@
 //  ReceiptAttributesValidation.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ReceiptAttributesValidation.swift
+++ b/ReceiptValidation/ReceiptAttributesValidation.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ReceiptChecksum.swift
+++ b/ReceiptValidation/ReceiptChecksum.swift
@@ -2,8 +2,8 @@
 //  ReceiptChecksum.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ReceiptChecksum.swift
+++ b/ReceiptValidation/ReceiptChecksum.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ReceiptValidation.swift
+++ b/ReceiptValidation/ReceiptValidation.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/ReceiptValidation.swift
+++ b/ReceiptValidation/ReceiptValidation.swift
@@ -2,8 +2,8 @@
 //  ReceiptValidation.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/SHA256Fingerprint.swift
+++ b/ReceiptValidation/SHA256Fingerprint.swift
@@ -2,8 +2,8 @@
 //  SHA256Fingerprint.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/SHA256Fingerprint.swift
+++ b/ReceiptValidation/SHA256Fingerprint.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/String+ASN1.swift
+++ b/ReceiptValidation/String+ASN1.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/String+ASN1.swift
+++ b/ReceiptValidation/String+ASN1.swift
@@ -2,8 +2,8 @@
 //  String+ASN1.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/main.swift
+++ b/ReceiptValidation/main.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/ReceiptValidation/main.swift
+++ b/ReceiptValidation/main.swift
@@ -2,8 +2,8 @@
 //  main.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABAddressBook+Localizing.h
+++ b/Telephone/AKABAddressBook+Localizing.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABAddressBook+Localizing.h
+++ b/Telephone/AKABAddressBook+Localizing.h
@@ -2,8 +2,8 @@
 //  AKABAddressBook+Localizing.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABAddressBook+Localizing.m
+++ b/Telephone/AKABAddressBook+Localizing.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABAddressBook+Localizing.m
+++ b/Telephone/AKABAddressBook+Localizing.m
@@ -2,8 +2,8 @@
 //  AKABAddressBook+Localizing.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABRecord+Querying.h
+++ b/Telephone/AKABRecord+Querying.h
@@ -2,8 +2,8 @@
 //  AKABRecord+Querying.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABRecord+Querying.h
+++ b/Telephone/AKABRecord+Querying.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABRecord+Querying.m
+++ b/Telephone/AKABRecord+Querying.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKABRecord+Querying.m
+++ b/Telephone/AKABRecord+Querying.m
@@ -2,8 +2,8 @@
 //  AKABRecord+Querying.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKActiveCallView.h
+++ b/Telephone/AKActiveCallView.h
@@ -2,8 +2,8 @@
 //  AKActiveCallView.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKActiveCallView.h
+++ b/Telephone/AKActiveCallView.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKActiveCallView.m
+++ b/Telephone/AKActiveCallView.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKActiveCallView.m
+++ b/Telephone/AKActiveCallView.m
@@ -2,8 +2,8 @@
 //  AKActiveCallView.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKKeychain.h
+++ b/Telephone/AKKeychain.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKKeychain.h
+++ b/Telephone/AKKeychain.h
@@ -2,8 +2,8 @@
 //  AKKeychain.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKKeychain.m
+++ b/Telephone/AKKeychain.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKKeychain.m
+++ b/Telephone/AKKeychain.m
@@ -2,8 +2,8 @@
 //  AKKeychain.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Escaping.h
+++ b/Telephone/AKNSString+Escaping.h
@@ -2,8 +2,8 @@
 //  AKNSString+Escaping.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Escaping.h
+++ b/Telephone/AKNSString+Escaping.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Escaping.m
+++ b/Telephone/AKNSString+Escaping.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Escaping.m
+++ b/Telephone/AKNSString+Escaping.m
@@ -2,8 +2,8 @@
 //  AKNSString+Escaping.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+PJSUA.h
+++ b/Telephone/AKNSString+PJSUA.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+PJSUA.h
+++ b/Telephone/AKNSString+PJSUA.h
@@ -2,8 +2,8 @@
 //  AKNSString+PJSUA.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+PJSUA.m
+++ b/Telephone/AKNSString+PJSUA.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+PJSUA.m
+++ b/Telephone/AKNSString+PJSUA.m
@@ -2,8 +2,8 @@
 //  AKNSString+PJSUA.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Scanning.h
+++ b/Telephone/AKNSString+Scanning.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Scanning.h
+++ b/Telephone/AKNSString+Scanning.h
@@ -2,8 +2,8 @@
 //  AKNSString+Scanning.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Scanning.m
+++ b/Telephone/AKNSString+Scanning.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSString+Scanning.m
+++ b/Telephone/AKNSString+Scanning.m
@@ -2,8 +2,8 @@
 //  AKNSString+Scanning.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSWindow+Resizing.h
+++ b/Telephone/AKNSWindow+Resizing.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSWindow+Resizing.h
+++ b/Telephone/AKNSWindow+Resizing.h
@@ -2,8 +2,8 @@
 //  AKNSWindow+Resizing.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSWindow+Resizing.m
+++ b/Telephone/AKNSWindow+Resizing.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNSWindow+Resizing.m
+++ b/Telephone/AKNSWindow+Resizing.m
@@ -2,8 +2,8 @@
 //  AKNSWindow+Resizing.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNetworkReachability.h
+++ b/Telephone/AKNetworkReachability.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNetworkReachability.h
+++ b/Telephone/AKNetworkReachability.h
@@ -2,8 +2,8 @@
 //  AKNetworkReachability.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNetworkReachability.m
+++ b/Telephone/AKNetworkReachability.m
@@ -2,8 +2,8 @@
 //  AKNetworkReachability.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKNetworkReachability.m
+++ b/Telephone/AKNetworkReachability.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -2,8 +2,8 @@
 //  AKSIPAccount.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPAccount.m
+++ b/Telephone/AKSIPAccount.m
@@ -2,8 +2,8 @@
 //  AKSIPAccount.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPAccount.m
+++ b/Telephone/AKSIPAccount.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPAccountDelegate.h
+++ b/Telephone/AKSIPAccountDelegate.h
@@ -2,8 +2,8 @@
 //  AKSIPAccountDelegate.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPAccountDelegate.h
+++ b/Telephone/AKSIPAccountDelegate.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCall.h
+++ b/Telephone/AKSIPCall.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCall.h
+++ b/Telephone/AKSIPCall.h
@@ -2,8 +2,8 @@
 //  AKSIPCall.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCall.m
+++ b/Telephone/AKSIPCall.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCall.m
+++ b/Telephone/AKSIPCall.m
@@ -2,8 +2,8 @@
 //  AKSIPCall.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCallDelegate.h
+++ b/Telephone/AKSIPCallDelegate.h
@@ -2,8 +2,8 @@
 //  AKSIPCallDelegate.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCallDelegate.h
+++ b/Telephone/AKSIPCallDelegate.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCallNotifications.h
+++ b/Telephone/AKSIPCallNotifications.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCallNotifications.h
+++ b/Telephone/AKSIPCallNotifications.h
@@ -2,8 +2,8 @@
 //  AKSIPCallNotifications.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCallNotifications.m
+++ b/Telephone/AKSIPCallNotifications.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPCallNotifications.m
+++ b/Telephone/AKSIPCallNotifications.m
@@ -2,8 +2,8 @@
 //  AKSIPCallNotifications.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURI.h
+++ b/Telephone/AKSIPURI.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURI.h
+++ b/Telephone/AKSIPURI.h
@@ -2,8 +2,8 @@
 //  AKSIPURI.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURI.m
+++ b/Telephone/AKSIPURI.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURI.m
+++ b/Telephone/AKSIPURI.m
@@ -2,8 +2,8 @@
 //  AKSIPURI.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURIFormatter.h
+++ b/Telephone/AKSIPURIFormatter.h
@@ -2,8 +2,8 @@
 //  AKSIPURIFormatter.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURIFormatter.h
+++ b/Telephone/AKSIPURIFormatter.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURIFormatter.m
+++ b/Telephone/AKSIPURIFormatter.m
@@ -2,8 +2,8 @@
 //  AKSIPURIFormatter.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPURIFormatter.m
+++ b/Telephone/AKSIPURIFormatter.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgent+UserAgent.swift
+++ b/Telephone/AKSIPUserAgent+UserAgent.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgent+UserAgent.swift
+++ b/Telephone/AKSIPUserAgent+UserAgent.swift
@@ -2,8 +2,8 @@
 //  AKSIPUserAgent+UserAgent.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgent.h
+++ b/Telephone/AKSIPUserAgent.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgent.h
+++ b/Telephone/AKSIPUserAgent.h
@@ -2,8 +2,8 @@
 //  AKSIPUserAgent.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -2,8 +2,8 @@
 //  AKSIPUserAgent.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgentDelegate.h
+++ b/Telephone/AKSIPUserAgentDelegate.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgentDelegate.h
+++ b/Telephone/AKSIPUserAgentDelegate.h
@@ -2,8 +2,8 @@
 //  AKSIPUserAgentDelegate.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgentNotifications.h
+++ b/Telephone/AKSIPUserAgentNotifications.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgentNotifications.h
+++ b/Telephone/AKSIPUserAgentNotifications.h
@@ -2,8 +2,8 @@
 //  AKSIPUserAgentNotifications.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgentNotifications.m
+++ b/Telephone/AKSIPUserAgentNotifications.m
@@ -2,8 +2,8 @@
 //  AKSIPUserAgentNotifications.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKSIPUserAgentNotifications.m
+++ b/Telephone/AKSIPUserAgentNotifications.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKTelephoneNumberFormatter.h
+++ b/Telephone/AKTelephoneNumberFormatter.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKTelephoneNumberFormatter.h
+++ b/Telephone/AKTelephoneNumberFormatter.h
@@ -2,8 +2,8 @@
 //  AKTelephoneNumberFormatter.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKTelephoneNumberFormatter.m
+++ b/Telephone/AKTelephoneNumberFormatter.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AKTelephoneNumberFormatter.m
+++ b/Telephone/AKTelephoneNumberFormatter.m
@@ -2,8 +2,8 @@
 //  AKTelephoneNumberFormatter.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountController.h
+++ b/Telephone/AccountController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountController.h
+++ b/Telephone/AccountController.h
@@ -2,8 +2,8 @@
 //  AccountController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -2,8 +2,8 @@
 //  AccountController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountPreferencesViewController.h
+++ b/Telephone/AccountPreferencesViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountPreferencesViewController.h
+++ b/Telephone/AccountPreferencesViewController.h
@@ -2,8 +2,8 @@
 //  AccountPreferencesViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountPreferencesViewController.m
+++ b/Telephone/AccountPreferencesViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountPreferencesViewController.m
+++ b/Telephone/AccountPreferencesViewController.m
@@ -2,8 +2,8 @@
 //  AccountPreferencesViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountSetupController.h
+++ b/Telephone/AccountSetupController.h
@@ -2,8 +2,8 @@
 //  AccountSetupController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountSetupController.h
+++ b/Telephone/AccountSetupController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountSetupController.m
+++ b/Telephone/AccountSetupController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountSetupController.m
+++ b/Telephone/AccountSetupController.m
@@ -2,8 +2,8 @@
 //  AccountSetupController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountUUIDSettingsMigration.swift
+++ b/Telephone/AccountUUIDSettingsMigration.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountUUIDSettingsMigration.swift
+++ b/Telephone/AccountUUIDSettingsMigration.swift
@@ -2,8 +2,8 @@
 //  AccountUUIDSettingsMigration.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountUUIDSettingsMigrationTests.swift
+++ b/Telephone/AccountUUIDSettingsMigrationTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AccountUUIDSettingsMigrationTests.swift
+++ b/Telephone/AccountUUIDSettingsMigrationTests.swift
@@ -2,8 +2,8 @@
 //  AccountUUIDSettingsMigrationTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountTransferViewController.h
+++ b/Telephone/ActiveAccountTransferViewController.h
@@ -2,8 +2,8 @@
 //  ActiveAccountTransferViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountTransferViewController.h
+++ b/Telephone/ActiveAccountTransferViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountTransferViewController.m
+++ b/Telephone/ActiveAccountTransferViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountTransferViewController.m
+++ b/Telephone/ActiveAccountTransferViewController.m
@@ -2,8 +2,8 @@
 //  ActiveAccountTransferViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountViewController.h
+++ b/Telephone/ActiveAccountViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountViewController.h
+++ b/Telephone/ActiveAccountViewController.h
@@ -2,8 +2,8 @@
 //  ActiveAccountViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountViewController.m
+++ b/Telephone/ActiveAccountViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveAccountViewController.m
+++ b/Telephone/ActiveAccountViewController.m
@@ -2,8 +2,8 @@
 //  ActiveAccountViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallTransferViewController.h
+++ b/Telephone/ActiveCallTransferViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallTransferViewController.h
+++ b/Telephone/ActiveCallTransferViewController.h
@@ -2,8 +2,8 @@
 //  ActiveCallTransferViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallTransferViewController.m
+++ b/Telephone/ActiveCallTransferViewController.m
@@ -2,8 +2,8 @@
 //  ActiveCallTransferViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallTransferViewController.m
+++ b/Telephone/ActiveCallTransferViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallViewController.h
+++ b/Telephone/ActiveCallViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallViewController.h
+++ b/Telephone/ActiveCallViewController.h
@@ -2,8 +2,8 @@
 //  ActiveCallViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallViewController.m
+++ b/Telephone/ActiveCallViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ActiveCallViewController.m
+++ b/Telephone/ActiveCallViewController.m
@@ -2,8 +2,8 @@
 //  ActiveCallViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppController+ConditionalRingtonePlaybackUseCaseDelegate.swift
+++ b/Telephone/AppController+ConditionalRingtonePlaybackUseCaseDelegate.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppController+ConditionalRingtonePlaybackUseCaseDelegate.swift
+++ b/Telephone/AppController+ConditionalRingtonePlaybackUseCaseDelegate.swift
@@ -2,8 +2,8 @@
 //  AppController+ConditionalRingtonePlaybackUseCaseDelegate.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppController.h
+++ b/Telephone/AppController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppController.h
+++ b/Telephone/AppController.h
@@ -2,8 +2,8 @@
 //  AppController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -2,8 +2,8 @@
 //  AppController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppleMusicPlayer.h
+++ b/Telephone/AppleMusicPlayer.h
@@ -2,8 +2,8 @@
 //  AppleMusicPlayer.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppleMusicPlayer.h
+++ b/Telephone/AppleMusicPlayer.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppleMusicPlayer.m
+++ b/Telephone/AppleMusicPlayer.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AppleMusicPlayer.m
+++ b/Telephone/AppleMusicPlayer.m
@@ -2,8 +2,8 @@
 //  AppleMusicPlayer.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ApplicationDataLocations.swift
+++ b/Telephone/ApplicationDataLocations.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ApplicationDataLocations.swift
+++ b/Telephone/ApplicationDataLocations.swift
@@ -2,8 +2,8 @@
 //  ApplicationDataLocations.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/Array+Creating.swift
+++ b/Telephone/Array+Creating.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/Array+Creating.swift
+++ b/Telephone/Array+Creating.swift
@@ -2,8 +2,8 @@
 //  Array+Creating.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AsyncFailingProductsFake.swift
+++ b/Telephone/AsyncFailingProductsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AsyncFailingProductsFake.swift
+++ b/Telephone/AsyncFailingProductsFake.swift
@@ -2,8 +2,8 @@
 //  AsyncFailingProductsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AsyncProductsFake.swift
+++ b/Telephone/AsyncProductsFake.swift
@@ -2,8 +2,8 @@
 //  AsyncProductsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AsyncProductsFake.swift
+++ b/Telephone/AsyncProductsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AuthenticationFailureController.h
+++ b/Telephone/AuthenticationFailureController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AuthenticationFailureController.h
+++ b/Telephone/AuthenticationFailureController.h
@@ -2,8 +2,8 @@
 //  AuthenticationFailureController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AuthenticationFailureController.m
+++ b/Telephone/AuthenticationFailureController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AuthenticationFailureController.m
+++ b/Telephone/AuthenticationFailureController.m
@@ -2,8 +2,8 @@
 //  AuthenticationFailureController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AvailableMusicPlayers.swift
+++ b/Telephone/AvailableMusicPlayers.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/AvailableMusicPlayers.swift
+++ b/Telephone/AvailableMusicPlayers.swift
@@ -2,8 +2,8 @@
 //  AvailableMusicPlayers.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/BundleReceipt.swift
+++ b/Telephone/BundleReceipt.swift
@@ -2,8 +2,8 @@
 //  BundleReceipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/BundleReceipt.swift
+++ b/Telephone/BundleReceipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallController+Protected.h
+++ b/Telephone/CallController+Protected.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallController+Protected.h
+++ b/Telephone/CallController+Protected.h
@@ -2,8 +2,8 @@
 //  CallController+Protected.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallController.h
+++ b/Telephone/CallController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallController.h
+++ b/Telephone/CallController.h
@@ -2,8 +2,8 @@
 //  CallController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallController.m
+++ b/Telephone/CallController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallController.m
+++ b/Telephone/CallController.m
@@ -2,8 +2,8 @@
 //  CallController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallControllerDelegate.h
+++ b/Telephone/CallControllerDelegate.h
@@ -2,8 +2,8 @@
 //  CallControllerDelegate.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallControllerDelegate.h
+++ b/Telephone/CallControllerDelegate.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryOutgoingCallCellView.swift
+++ b/Telephone/CallHistoryOutgoingCallCellView.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryOutgoingCallCellView.swift
+++ b/Telephone/CallHistoryOutgoingCallCellView.swift
@@ -2,8 +2,8 @@
 //  CallHistoryOutgoingCallCellView.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryView.swift
+++ b/Telephone/CallHistoryView.swift
@@ -2,8 +2,8 @@
 //  CallHistoryView.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryView.swift
+++ b/Telephone/CallHistoryView.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewController.swift
+++ b/Telephone/CallHistoryViewController.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewController.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewController.swift
+++ b/Telephone/CallHistoryViewController.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewEventTarget.swift
+++ b/Telephone/CallHistoryViewEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewEventTarget.swift
+++ b/Telephone/CallHistoryViewEventTarget.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewEventTargetFactory.swift
+++ b/Telephone/CallHistoryViewEventTargetFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewEventTargetFactory.swift
+++ b/Telephone/CallHistoryViewEventTargetFactory.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewEventTargetFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewPresenter.swift
+++ b/Telephone/CallHistoryViewPresenter.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewPresenter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallHistoryViewPresenter.swift
+++ b/Telephone/CallHistoryViewPresenter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallNotificationsToEventTargetAdapter.swift
+++ b/Telephone/CallNotificationsToEventTargetAdapter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallNotificationsToEventTargetAdapter.swift
+++ b/Telephone/CallNotificationsToEventTargetAdapter.swift
@@ -2,8 +2,8 @@
 //  CallNotificationsToEventTargetAdapter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallTransferController.h
+++ b/Telephone/CallTransferController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallTransferController.h
+++ b/Telephone/CallTransferController.h
@@ -2,8 +2,8 @@
 //  CallTransferController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallTransferController.m
+++ b/Telephone/CallTransferController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CallTransferController.m
+++ b/Telephone/CallTransferController.m
@@ -2,8 +2,8 @@
 //  CallTransferController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -2,8 +2,8 @@
 //  CompositionRoot.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultCallHistoryRecordAddUseCaseFactory.swift
+++ b/Telephone/DefaultCallHistoryRecordAddUseCaseFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultCallHistoryRecordAddUseCaseFactory.swift
+++ b/Telephone/DefaultCallHistoryRecordAddUseCaseFactory.swift
@@ -2,8 +2,8 @@
 //  DefaultCallHistoryRecordAddUseCaseFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultSettingsMigrationFactory.swift
+++ b/Telephone/DefaultSettingsMigrationFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultSettingsMigrationFactory.swift
+++ b/Telephone/DefaultSettingsMigrationFactory.swift
@@ -2,8 +2,8 @@
 //  DefaultSettingsMigrationFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultSoundPreferencesViewEventTarget.swift
+++ b/Telephone/DefaultSoundPreferencesViewEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultSoundPreferencesViewEventTarget.swift
+++ b/Telephone/DefaultSoundPreferencesViewEventTarget.swift
@@ -2,8 +2,8 @@
 //  DefaultSoundPreferencesViewEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreUseCaseFactory.swift
+++ b/Telephone/DefaultStoreUseCaseFactory.swift
@@ -2,8 +2,8 @@
 //  DefaultStoreUseCaseFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreUseCaseFactory.swift
+++ b/Telephone/DefaultStoreUseCaseFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreViewEventTarget.swift
+++ b/Telephone/DefaultStoreViewEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreViewEventTarget.swift
+++ b/Telephone/DefaultStoreViewEventTarget.swift
@@ -2,8 +2,8 @@
 //  DefaultStoreViewEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreViewEventTargetTests.swift
+++ b/Telephone/DefaultStoreViewEventTargetTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreViewEventTargetTests.swift
+++ b/Telephone/DefaultStoreViewEventTargetTests.swift
@@ -2,8 +2,8 @@
 //  DefaultStoreViewEventTargetTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreViewPresenter.swift
+++ b/Telephone/DefaultStoreViewPresenter.swift
@@ -2,8 +2,8 @@
 //  DefaultStoreViewPresenter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultStoreViewPresenter.swift
+++ b/Telephone/DefaultStoreViewPresenter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultUseCaseFactory.swift
+++ b/Telephone/DefaultUseCaseFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DefaultUseCaseFactory.swift
+++ b/Telephone/DefaultUseCaseFactory.swift
@@ -2,8 +2,8 @@
 //  DefaultUseCaseFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DirectoryCreatingApplicationDataLocations.swift
+++ b/Telephone/DirectoryCreatingApplicationDataLocations.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DirectoryCreatingApplicationDataLocations.swift
+++ b/Telephone/DirectoryCreatingApplicationDataLocations.swift
@@ -2,8 +2,8 @@
 //  DirectoryCreatingApplicationDataLocations.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DurationFormatter.swift
+++ b/Telephone/DurationFormatter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/DurationFormatter.swift
+++ b/Telephone/DurationFormatter.swift
@@ -2,8 +2,8 @@
 //  DurationFormatter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallTransferViewController.h
+++ b/Telephone/EndedCallTransferViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallTransferViewController.h
+++ b/Telephone/EndedCallTransferViewController.h
@@ -2,8 +2,8 @@
 //  EndedCallTransferViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallTransferViewController.m
+++ b/Telephone/EndedCallTransferViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallTransferViewController.m
+++ b/Telephone/EndedCallTransferViewController.m
@@ -2,8 +2,8 @@
 //  EndedCallTransferViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallViewController.h
+++ b/Telephone/EndedCallViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallViewController.h
+++ b/Telephone/EndedCallViewController.h
@@ -2,8 +2,8 @@
 //  EndedCallViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallViewController.m
+++ b/Telephone/EndedCallViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/EndedCallViewController.m
+++ b/Telephone/EndedCallViewController.m
@@ -2,8 +2,8 @@
 //  EndedCallViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ExpectedProducts.swift
+++ b/Telephone/ExpectedProducts.swift
@@ -2,8 +2,8 @@
 //  ExpectedProducts.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ExpectedProducts.swift
+++ b/Telephone/ExpectedProducts.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/FailingStoreFake.swift
+++ b/Telephone/FailingStoreFake.swift
@@ -2,8 +2,8 @@
 //  FailingStoreFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/FailingStoreFake.swift
+++ b/Telephone/FailingStoreFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/FoundationToUseCasesTimerAdapter.swift
+++ b/Telephone/FoundationToUseCasesTimerAdapter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/FoundationToUseCasesTimerAdapter.swift
+++ b/Telephone/FoundationToUseCasesTimerAdapter.swift
@@ -2,8 +2,8 @@
 //  FoundationToUseCasesTimerAdapter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/FoundationToUseCasesTimerAdapterFactory.swift
+++ b/Telephone/FoundationToUseCasesTimerAdapterFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/FoundationToUseCasesTimerAdapterFactory.swift
+++ b/Telephone/FoundationToUseCasesTimerAdapterFactory.swift
@@ -2,8 +2,8 @@
 //  FoundationToUseCasesTimerAdapterFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/GeneralPreferencesViewController.h
+++ b/Telephone/GeneralPreferencesViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/GeneralPreferencesViewController.h
+++ b/Telephone/GeneralPreferencesViewController.h
@@ -2,8 +2,8 @@
 //  GeneralPreferencesViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/GeneralPreferencesViewController.m
+++ b/Telephone/GeneralPreferencesViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/GeneralPreferencesViewController.m
+++ b/Telephone/GeneralPreferencesViewController.m
@@ -2,8 +2,8 @@
 //  GeneralPreferencesViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/IncomingCallViewController.h
+++ b/Telephone/IncomingCallViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/IncomingCallViewController.h
+++ b/Telephone/IncomingCallViewController.h
@@ -2,8 +2,8 @@
 //  IncomingCallViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/IncomingCallViewController.m
+++ b/Telephone/IncomingCallViewController.m
@@ -2,8 +2,8 @@
 //  IncomingCallViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/IncomingCallViewController.m
+++ b/Telephone/IncomingCallViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/Info.plist
+++ b/Telephone/Info.plist
@@ -48,7 +48,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>© 2016 64 Characters</string>
+	<string>© 2016–2017 64 Characters</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/Telephone/LoggingProducts.swift
+++ b/Telephone/LoggingProducts.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/LoggingProducts.swift
+++ b/Telephone/LoggingProducts.swift
@@ -2,8 +2,8 @@
 //  LoggingProducts.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/LoggingReceipt.swift
+++ b/Telephone/LoggingReceipt.swift
@@ -2,8 +2,8 @@
 //  LoggingReceipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/LoggingReceipt.swift
+++ b/Telephone/LoggingReceipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/LoggingStore.swift
+++ b/Telephone/LoggingStore.swift
@@ -2,8 +2,8 @@
 //  LoggingStore.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/LoggingStore.swift
+++ b/Telephone/LoggingStore.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/MusicPlayerFactory.h
+++ b/Telephone/MusicPlayerFactory.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/MusicPlayerFactory.h
+++ b/Telephone/MusicPlayerFactory.h
@@ -2,8 +2,8 @@
 //  MusicPlayerFactory.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/MusicPlayerFactory.m
+++ b/Telephone/MusicPlayerFactory.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/MusicPlayerFactory.m
+++ b/Telephone/MusicPlayerFactory.m
@@ -2,8 +2,8 @@
 //  MusicPlayerFactory.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/MusicPlayers.swift
+++ b/Telephone/MusicPlayers.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/MusicPlayers.swift
+++ b/Telephone/MusicPlayers.swift
@@ -2,8 +2,8 @@
 //  MusicPlayers.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NSSoundToSoundAdapter.swift
+++ b/Telephone/NSSoundToSoundAdapter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NSSoundToSoundAdapter.swift
+++ b/Telephone/NSSoundToSoundAdapter.swift
@@ -2,8 +2,8 @@
 //  NSSoundToSoundAdapter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NSSoundToSoundAdapterFactory.swift
+++ b/Telephone/NSSoundToSoundAdapterFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NSSoundToSoundAdapterFactory.swift
+++ b/Telephone/NSSoundToSoundAdapterFactory.swift
@@ -2,8 +2,8 @@
 //  NSSoundToSoundAdapterFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NSUserDefaults+KeyValueSettings.swift
+++ b/Telephone/NSUserDefaults+KeyValueSettings.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NSUserDefaults+KeyValueSettings.swift
+++ b/Telephone/NSUserDefaults+KeyValueSettings.swift
@@ -2,8 +2,8 @@
 //  NSUserDefaults+KeyValueSettings.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NetworkPreferencesViewController.h
+++ b/Telephone/NetworkPreferencesViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NetworkPreferencesViewController.h
+++ b/Telephone/NetworkPreferencesViewController.h
@@ -2,8 +2,8 @@
 //  NetworkPreferencesViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NetworkPreferencesViewController.m
+++ b/Telephone/NetworkPreferencesViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NetworkPreferencesViewController.m
+++ b/Telephone/NetworkPreferencesViewController.m
@@ -2,8 +2,8 @@
 //  NetworkPreferencesViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NotifyingCallHistoryFactory.swift
+++ b/Telephone/NotifyingCallHistoryFactory.swift
@@ -2,8 +2,8 @@
 //  NotifyingCallHistoryFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NotifyingCallHistoryFactory.swift
+++ b/Telephone/NotifyingCallHistoryFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NullStoreViewEventTarget.swift
+++ b/Telephone/NullStoreViewEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/NullStoreViewEventTarget.swift
+++ b/Telephone/NullStoreViewEventTarget.swift
@@ -2,8 +2,8 @@
 //  NullStoreViewEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUACallbacks.h
+++ b/Telephone/PJSUACallbacks.h
@@ -2,8 +2,8 @@
 //  PJSUACallbacks.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUACallbacks.h
+++ b/Telephone/PJSUACallbacks.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnAccountRegistrationState.m
+++ b/Telephone/PJSUAOnAccountRegistrationState.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnAccountRegistrationState.m
+++ b/Telephone/PJSUAOnAccountRegistrationState.m
@@ -2,8 +2,8 @@
 //  PJSUAOnAccountRegistrationState.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallMediaState.m
+++ b/Telephone/PJSUAOnCallMediaState.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallMediaState.m
+++ b/Telephone/PJSUAOnCallMediaState.m
@@ -2,8 +2,8 @@
 //  PJSUAOnCallMediaState.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallReplaced.m
+++ b/Telephone/PJSUAOnCallReplaced.m
@@ -2,8 +2,8 @@
 //  PJSUAOnCallReplaced.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallReplaced.m
+++ b/Telephone/PJSUAOnCallReplaced.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallState.m
+++ b/Telephone/PJSUAOnCallState.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallState.m
+++ b/Telephone/PJSUAOnCallState.m
@@ -2,8 +2,8 @@
 //  PJSUAOnCallState.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallTransferStatus.m
+++ b/Telephone/PJSUAOnCallTransferStatus.m
@@ -2,8 +2,8 @@
 //  PJSUAOnCallTransferStatus.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnCallTransferStatus.m
+++ b/Telephone/PJSUAOnCallTransferStatus.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnIncomingCall.m
+++ b/Telephone/PJSUAOnIncomingCall.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnIncomingCall.m
+++ b/Telephone/PJSUAOnIncomingCall.m
@@ -2,8 +2,8 @@
 //  PJSUAOnIncomingCall.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnNATDetect.m
+++ b/Telephone/PJSUAOnNATDetect.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PJSUAOnNATDetect.m
+++ b/Telephone/PJSUAOnNATDetect.m
@@ -2,8 +2,8 @@
 //  PJSUAOnNATDetect.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PersistentCallHistoryFactory.swift
+++ b/Telephone/PersistentCallHistoryFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PersistentCallHistoryFactory.swift
+++ b/Telephone/PersistentCallHistoryFactory.swift
@@ -2,8 +2,8 @@
 //  PersistentCallHistoryFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesController.h
+++ b/Telephone/PreferencesController.h
@@ -2,8 +2,8 @@
 //  PreferencesController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesController.h
+++ b/Telephone/PreferencesController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesController.m
+++ b/Telephone/PreferencesController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesController.m
+++ b/Telephone/PreferencesController.m
@@ -2,8 +2,8 @@
 //  PreferencesController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesControllerDelegate.h
+++ b/Telephone/PreferencesControllerDelegate.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesControllerDelegate.h
+++ b/Telephone/PreferencesControllerDelegate.h
@@ -2,8 +2,8 @@
 //  PreferencesControllerDelegate.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesSoundIOUpdater.swift
+++ b/Telephone/PreferencesSoundIOUpdater.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PreferencesSoundIOUpdater.swift
+++ b/Telephone/PreferencesSoundIOUpdater.swift
@@ -2,8 +2,8 @@
 //  PreferencesSoundIOUpdater.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationCallHistoryRecord.swift
+++ b/Telephone/PresentationCallHistoryRecord.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationCallHistoryRecord.swift
+++ b/Telephone/PresentationCallHistoryRecord.swift
@@ -2,8 +2,8 @@
 //  PresentationCallHistoryRecord.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationContact.swift
+++ b/Telephone/PresentationContact.swift
@@ -2,8 +2,8 @@
 //  PresentationContact.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationContact.swift
+++ b/Telephone/PresentationContact.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationContactAddress.swift
+++ b/Telephone/PresentationContactAddress.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationContactAddress.swift
+++ b/Telephone/PresentationContactAddress.swift
@@ -2,8 +2,8 @@
 //  PresentationContactAddress.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationProduct.swift
+++ b/Telephone/PresentationProduct.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresentationProduct.swift
+++ b/Telephone/PresentationProduct.swift
@@ -2,8 +2,8 @@
 //  PresentationProduct.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresenterFactory.swift
+++ b/Telephone/PresenterFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/PresenterFactory.swift
+++ b/Telephone/PresenterFactory.swift
@@ -2,8 +2,8 @@
 //  PresenterFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/Product+SKProduct.swift
+++ b/Telephone/Product+SKProduct.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/Product+SKProduct.swift
+++ b/Telephone/Product+SKProduct.swift
@@ -2,8 +2,8 @@
 //  Product+SKProduct.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ProgressiveSettingsMigration.swift
+++ b/Telephone/ProgressiveSettingsMigration.swift
@@ -2,8 +2,8 @@
 //  ProgressiveSettingsMigration.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ProgressiveSettingsMigration.swift
+++ b/Telephone/ProgressiveSettingsMigration.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ReceiptXPCGateway.swift
+++ b/Telephone/ReceiptXPCGateway.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ReceiptXPCGateway.swift
+++ b/Telephone/ReceiptXPCGateway.swift
@@ -2,8 +2,8 @@
 //  ReceiptXPCGateway.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/RepeatingSoundFactory.swift
+++ b/Telephone/RepeatingSoundFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/RepeatingSoundFactory.swift
+++ b/Telephone/RepeatingSoundFactory.swift
@@ -2,8 +2,8 @@
 //  RepeatingSoundFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/RepeatingSoundFactoryTests.swift
+++ b/Telephone/RepeatingSoundFactoryTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/RepeatingSoundFactoryTests.swift
+++ b/Telephone/RepeatingSoundFactoryTests.swift
@@ -2,8 +2,8 @@
 //  RepeatingSoundFactoryTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SKPaymentQueueToStoreAdapter.swift
+++ b/Telephone/SKPaymentQueueToStoreAdapter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SKPaymentQueueToStoreAdapter.swift
+++ b/Telephone/SKPaymentQueueToStoreAdapter.swift
@@ -2,8 +2,8 @@
 //  SKPaymentQueueToStoreAdapter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SKProductsRequestToProductsAdapter.swift
+++ b/Telephone/SKProductsRequestToProductsAdapter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SKProductsRequestToProductsAdapter.swift
+++ b/Telephone/SKProductsRequestToProductsAdapter.swift
@@ -2,8 +2,8 @@
 //  SKProductsRequestToProductsAdapter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsAccount.swift
+++ b/Telephone/SettingsAccount.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsAccount.swift
+++ b/Telephone/SettingsAccount.swift
@@ -2,8 +2,8 @@
 //  SettingsAccount.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsAccounts.swift
+++ b/Telephone/SettingsAccounts.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsAccounts.swift
+++ b/Telephone/SettingsAccounts.swift
@@ -2,8 +2,8 @@
 //  SettingsAccounts.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsMigration.swift
+++ b/Telephone/SettingsMigration.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsMigration.swift
+++ b/Telephone/SettingsMigration.swift
@@ -2,8 +2,8 @@
 //  SettingsMigration.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsMigrationFactory.swift
+++ b/Telephone/SettingsMigrationFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SettingsMigrationFactory.swift
+++ b/Telephone/SettingsMigrationFactory.swift
@@ -2,8 +2,8 @@
 //  SettingsMigrationFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ShortRelativeDateTimeFormatter.swift
+++ b/Telephone/ShortRelativeDateTimeFormatter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ShortRelativeDateTimeFormatter.swift
+++ b/Telephone/ShortRelativeDateTimeFormatter.swift
@@ -2,8 +2,8 @@
 //  ShortRelativeDateTimeFormatter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimpleApplicationDataLocations.swift
+++ b/Telephone/SimpleApplicationDataLocations.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimpleApplicationDataLocations.swift
+++ b/Telephone/SimpleApplicationDataLocations.swift
@@ -2,8 +2,8 @@
 //  SimpleApplicationDataLocations.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimplePropertyListStorage.swift
+++ b/Telephone/SimplePropertyListStorage.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimplePropertyListStorage.swift
+++ b/Telephone/SimplePropertyListStorage.swift
@@ -2,8 +2,8 @@
 //  SimplePropertyListStorage.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimplePropertyListStorageFactory.swift
+++ b/Telephone/SimplePropertyListStorageFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimplePropertyListStorageFactory.swift
+++ b/Telephone/SimplePropertyListStorageFactory.swift
@@ -2,8 +2,8 @@
 //  SimplePropertyListStorageFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimpleSoundFactory.swift
+++ b/Telephone/SimpleSoundFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SimpleSoundFactory.swift
+++ b/Telephone/SimpleSoundFactory.swift
@@ -2,8 +2,8 @@
 //  SimpleSoundFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundIOPreferences.h
+++ b/Telephone/SoundIOPreferences.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundIOPreferences.h
+++ b/Telephone/SoundIOPreferences.h
@@ -2,8 +2,8 @@
 //  SoundIOPreferences.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundIOPresenter.swift
+++ b/Telephone/SoundIOPresenter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundIOPresenter.swift
+++ b/Telephone/SoundIOPresenter.swift
@@ -2,8 +2,8 @@
 //  SoundIOPresenter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundIOPresenterOutput.h
+++ b/Telephone/SoundIOPresenterOutput.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundIOPresenterOutput.h
+++ b/Telephone/SoundIOPresenterOutput.h
@@ -2,8 +2,8 @@
 //  SoundIOPresenterOutput.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesView.h
+++ b/Telephone/SoundPreferencesView.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesView.h
+++ b/Telephone/SoundPreferencesView.h
@@ -2,8 +2,8 @@
 //  SoundPreferencesView.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesViewController.h
+++ b/Telephone/SoundPreferencesViewController.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesViewController.h
+++ b/Telephone/SoundPreferencesViewController.h
@@ -2,8 +2,8 @@
 //  SoundPreferencesViewController.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesViewController.m
+++ b/Telephone/SoundPreferencesViewController.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesViewController.m
+++ b/Telephone/SoundPreferencesViewController.m
@@ -2,8 +2,8 @@
 //  SoundPreferencesViewController.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesViewEventTarget.swift
+++ b/Telephone/SoundPreferencesViewEventTarget.swift
@@ -2,8 +2,8 @@
 //  SoundPreferencesViewEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SoundPreferencesViewEventTarget.swift
+++ b/Telephone/SoundPreferencesViewEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SpotifyMusicPlayer.h
+++ b/Telephone/SpotifyMusicPlayer.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SpotifyMusicPlayer.h
+++ b/Telephone/SpotifyMusicPlayer.h
@@ -2,8 +2,8 @@
 //  SpotifyMusicPlayer.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SpotifyMusicPlayer.m
+++ b/Telephone/SpotifyMusicPlayer.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SpotifyMusicPlayer.m
+++ b/Telephone/SpotifyMusicPlayer.m
@@ -2,8 +2,8 @@
 //  SpotifyMusicPlayer.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreEventSource.swift
+++ b/Telephone/StoreEventSource.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreEventSource.swift
+++ b/Telephone/StoreEventSource.swift
@@ -2,8 +2,8 @@
 //  StoreEventSource.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreKitProducts.swift
+++ b/Telephone/StoreKitProducts.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreKitProducts.swift
+++ b/Telephone/StoreKitProducts.swift
@@ -2,8 +2,8 @@
 //  StoreKitProducts.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreView.swift
+++ b/Telephone/StoreView.swift
@@ -2,8 +2,8 @@
 //  StoreView.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreView.swift
+++ b/Telephone/StoreView.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewController.swift
+++ b/Telephone/StoreViewController.swift
@@ -2,8 +2,8 @@
 //  StoreViewController.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewController.swift
+++ b/Telephone/StoreViewController.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewEventTarget.swift
+++ b/Telephone/StoreViewEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewEventTarget.swift
+++ b/Telephone/StoreViewEventTarget.swift
@@ -2,8 +2,8 @@
 //  StoreViewEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewPresenter.swift
+++ b/Telephone/StoreViewPresenter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewPresenter.swift
+++ b/Telephone/StoreViewPresenter.swift
@@ -2,8 +2,8 @@
 //  StoreViewPresenter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewState.swift
+++ b/Telephone/StoreViewState.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewState.swift
+++ b/Telephone/StoreViewState.swift
@@ -2,8 +2,8 @@
 //  StoreViewState.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewStateMachine.swift
+++ b/Telephone/StoreViewStateMachine.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreViewStateMachine.swift
+++ b/Telephone/StoreViewStateMachine.swift
@@ -2,8 +2,8 @@
 //  StoreViewStateMachine.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreWindowController.swift
+++ b/Telephone/StoreWindowController.swift
@@ -2,8 +2,8 @@
 //  StoreWindowController.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/StoreWindowController.swift
+++ b/Telephone/StoreWindowController.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioDeviceIDs.swift
+++ b/Telephone/SystemAudioDeviceIDs.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioDeviceIDs.swift
+++ b/Telephone/SystemAudioDeviceIDs.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDeviceIDs.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioDevices.swift
+++ b/Telephone/SystemAudioDevices.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioDevices.swift
+++ b/Telephone/SystemAudioDevices.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevices.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioDevicesChangeEventSource.swift
+++ b/Telephone/SystemAudioDevicesChangeEventSource.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioDevicesChangeEventSource.swift
+++ b/Telephone/SystemAudioDevicesChangeEventSource.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevicesChangeEventSource.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioObject.swift
+++ b/Telephone/SystemAudioObject.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/SystemAudioObject.swift
+++ b/Telephone/SystemAudioObject.swift
@@ -2,8 +2,8 @@
 //  SystemAudioObject.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/TelephoneError.swift
+++ b/Telephone/TelephoneError.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/TelephoneError.swift
+++ b/Telephone/TelephoneError.swift
@@ -2,8 +2,8 @@
 //  TelephoneError.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/TruncatingCallHistoryFactory.swift
+++ b/Telephone/TruncatingCallHistoryFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/TruncatingCallHistoryFactory.swift
+++ b/Telephone/TruncatingCallHistoryFactory.swift
@@ -2,8 +2,8 @@
 //  TruncatingCallHistoryFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentAudioDevice+PJSIP.swift
+++ b/Telephone/UserAgentAudioDevice+PJSIP.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentAudioDevice+PJSIP.swift
+++ b/Telephone/UserAgentAudioDevice+PJSIP.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevice+PJSIP.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentAudioDevices.swift
+++ b/Telephone/UserAgentAudioDevices.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentAudioDevices.swift
+++ b/Telephone/UserAgentAudioDevices.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevices.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentError.swift
+++ b/Telephone/UserAgentError.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentError.swift
+++ b/Telephone/UserAgentError.swift
@@ -2,8 +2,8 @@
 //  UserAgentError.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentNotificationsToEventTargetAdapter.swift
+++ b/Telephone/UserAgentNotificationsToEventTargetAdapter.swift
@@ -2,8 +2,8 @@
 //  UserAgentNotificationsToEventTargetAdapter.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserAgentNotificationsToEventTargetAdapter.swift
+++ b/Telephone/UserAgentNotificationsToEventTargetAdapter.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserDefaultsKeys.h
+++ b/Telephone/UserDefaultsKeys.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserDefaultsKeys.h
+++ b/Telephone/UserDefaultsKeys.h
@@ -2,8 +2,8 @@
 //  UserDefaultsKeys.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserDefaultsKeys.m
+++ b/Telephone/UserDefaultsKeys.m
@@ -2,8 +2,8 @@
 //  UserDefaultsKeys.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserDefaultsKeys.m
+++ b/Telephone/UserDefaultsKeys.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserDefaultsPurchaseReminderSettings.swift
+++ b/Telephone/UserDefaultsPurchaseReminderSettings.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/UserDefaultsPurchaseReminderSettings.swift
+++ b/Telephone/UserDefaultsPurchaseReminderSettings.swift
@@ -2,8 +2,8 @@
 //  UserDefaultsPurchaseReminderSettings.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/WorkspaceSleepStatus.swift
+++ b/Telephone/WorkspaceSleepStatus.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/WorkspaceSleepStatus.swift
+++ b/Telephone/WorkspaceSleepStatus.swift
@@ -2,8 +2,8 @@
 //  WorkspaceSleepStatus.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/de.lproj/InfoPlist.strings
+++ b/Telephone/de.lproj/InfoPlist.strings
@@ -2,4 +2,3 @@
 
 CFBundleName				= "Telefon";
 CFBundleDisplayName			= "Telefon";
-NSHumanReadableCopyright	= "\U00A9 2016 64 Characters";

--- a/Telephone/en.lproj/InfoPlist.strings
+++ b/Telephone/en.lproj/InfoPlist.strings
@@ -2,4 +2,3 @@
 
 CFBundleName				= "Telephone";
 CFBundleDisplayName			= "Telephone";
-NSHumanReadableCopyright	= "\U00A9 2016 64 Characters";

--- a/Telephone/main.m
+++ b/Telephone/main.m
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/main.m
+++ b/Telephone/main.m
@@ -2,8 +2,8 @@
 //  main.m
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/Telephone/ru.lproj/InfoPlist.strings
+++ b/Telephone/ru.lproj/InfoPlist.strings
@@ -2,4 +2,3 @@
 
 CFBundleName				= "Телефон";
 CFBundleDisplayName			= "Телефон";
-NSHumanReadableCopyright	= "\U00A9 2016 64 Characters";

--- a/TelephoneTests/CallHistoryViewEventTargetTests.swift
+++ b/TelephoneTests/CallHistoryViewEventTargetTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallHistoryViewEventTargetTests.swift
+++ b/TelephoneTests/CallHistoryViewEventTargetTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewEventTargetTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallHistoryViewPresenterTests.swift
+++ b/TelephoneTests/CallHistoryViewPresenterTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallHistoryViewPresenterTests.swift
+++ b/TelephoneTests/CallHistoryViewPresenterTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewPresenterTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallHistoryViewSpy.swift
+++ b/TelephoneTests/CallHistoryViewSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallHistoryViewSpy.swift
+++ b/TelephoneTests/CallHistoryViewSpy.swift
@@ -2,8 +2,8 @@
 //  CallHistoryViewSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallNotificationsToEventTargetAdapterTests.swift
+++ b/TelephoneTests/CallNotificationsToEventTargetAdapterTests.swift
@@ -2,8 +2,8 @@
 //  CallNotificationsToEventTargetAdapterTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/CallNotificationsToEventTargetAdapterTests.swift
+++ b/TelephoneTests/CallNotificationsToEventTargetAdapterTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/DefaultSoundPreferencesViewEventTargetTests.swift
+++ b/TelephoneTests/DefaultSoundPreferencesViewEventTargetTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/DefaultSoundPreferencesViewEventTargetTests.swift
+++ b/TelephoneTests/DefaultSoundPreferencesViewEventTargetTests.swift
@@ -2,8 +2,8 @@
 //  DefaultSoundPreferencesViewEventTargetTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/DefaultStoreViewPresenterTests.swift
+++ b/TelephoneTests/DefaultStoreViewPresenterTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/DefaultStoreViewPresenterTests.swift
+++ b/TelephoneTests/DefaultStoreViewPresenterTests.swift
@@ -2,8 +2,8 @@
 //  DefaultStoreViewPresenterTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/MusicPlayersTests.swift
+++ b/TelephoneTests/MusicPlayersTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/MusicPlayersTests.swift
+++ b/TelephoneTests/MusicPlayersTests.swift
@@ -2,8 +2,8 @@
 //  MusicPlayersTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/PreferencesSoundIOUpdaterTests.swift
+++ b/TelephoneTests/PreferencesSoundIOUpdaterTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/PreferencesSoundIOUpdaterTests.swift
+++ b/TelephoneTests/PreferencesSoundIOUpdaterTests.swift
@@ -2,8 +2,8 @@
 //  PreferencesSoundIOUpdaterTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/ProgressiveSettingsMigrationTests.swift
+++ b/TelephoneTests/ProgressiveSettingsMigrationTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/ProgressiveSettingsMigrationTests.swift
+++ b/TelephoneTests/ProgressiveSettingsMigrationTests.swift
@@ -2,8 +2,8 @@
 //  ProgressiveSettingsMigrationTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SettingsAccountsTests.swift
+++ b/TelephoneTests/SettingsAccountsTests.swift
@@ -2,8 +2,8 @@
 //  SettingsAccountsTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SettingsAccountsTests.swift
+++ b/TelephoneTests/SettingsAccountsTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SettingsMigrationFactoryStub.swift
+++ b/TelephoneTests/SettingsMigrationFactoryStub.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SettingsMigrationFactoryStub.swift
+++ b/TelephoneTests/SettingsMigrationFactoryStub.swift
@@ -2,8 +2,8 @@
 //  SettingsMigrationFactoryStub.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SettingsMigrationSpy.swift
+++ b/TelephoneTests/SettingsMigrationSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SettingsMigrationSpy.swift
+++ b/TelephoneTests/SettingsMigrationSpy.swift
@@ -2,8 +2,8 @@
 //  SettingsMigrationSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SoundIOPreferencesSpy.swift
+++ b/TelephoneTests/SoundIOPreferencesSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SoundIOPreferencesSpy.swift
+++ b/TelephoneTests/SoundIOPreferencesSpy.swift
@@ -2,8 +2,8 @@
 //  SoundIOPreferencesSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SoundIOPresenterTests.swift
+++ b/TelephoneTests/SoundIOPresenterTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SoundIOPresenterTests.swift
+++ b/TelephoneTests/SoundIOPresenterTests.swift
@@ -2,8 +2,8 @@
 //  SoundIOPresenterTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SoundPreferencesViewSpy.swift
+++ b/TelephoneTests/SoundPreferencesViewSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/SoundPreferencesViewSpy.swift
+++ b/TelephoneTests/SoundPreferencesViewSpy.swift
@@ -2,8 +2,8 @@
 //  SoundPreferencesViewSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewDummy.swift
+++ b/TelephoneTests/StoreViewDummy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewDummy.swift
+++ b/TelephoneTests/StoreViewDummy.swift
@@ -2,8 +2,8 @@
 //  StoreViewDummy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewPresenterSpy.swift
+++ b/TelephoneTests/StoreViewPresenterSpy.swift
@@ -2,8 +2,8 @@
 //  StoreViewPresenterSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewPresenterSpy.swift
+++ b/TelephoneTests/StoreViewPresenterSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewSpy.swift
+++ b/TelephoneTests/StoreViewSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewSpy.swift
+++ b/TelephoneTests/StoreViewSpy.swift
@@ -2,8 +2,8 @@
 //  StoreViewSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewStateMachineTests.swift
+++ b/TelephoneTests/StoreViewStateMachineTests.swift
@@ -2,8 +2,8 @@
 //  StoreViewStateMachineTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/StoreViewStateMachineTests.swift
+++ b/TelephoneTests/StoreViewStateMachineTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/UserAgentNotificationsToEventTargetAdapterTests.swift
+++ b/TelephoneTests/UserAgentNotificationsToEventTargetAdapterTests.swift
@@ -2,8 +2,8 @@
 //  UserAgentNotificationsToObservingAdapterTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/UserAgentNotificationsToEventTargetAdapterTests.swift
+++ b/TelephoneTests/UserAgentNotificationsToEventTargetAdapterTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/WorkspaceSleepStatusTests.swift
+++ b/TelephoneTests/WorkspaceSleepStatusTests.swift
@@ -2,8 +2,8 @@
 //  WorkspaceSleepStatusTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/TelephoneTests/WorkspaceSleepStatusTests.swift
+++ b/TelephoneTests/WorkspaceSleepStatusTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Account.swift
+++ b/UseCases/Account.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Account.swift
+++ b/UseCases/Account.swift
@@ -2,8 +2,8 @@
 //  Account.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Accounts.swift
+++ b/UseCases/Accounts.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Accounts.swift
+++ b/UseCases/Accounts.swift
@@ -2,8 +2,8 @@
 //  Accounts.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/AudioDevice.swift
+++ b/UseCases/AudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/AudioDevice.swift
+++ b/UseCases/AudioDevice.swift
@@ -2,8 +2,8 @@
 //  AudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/AudioDevices.swift
+++ b/UseCases/AudioDevices.swift
@@ -2,8 +2,8 @@
 //  AudioDevices.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/AudioDevices.swift
+++ b/UseCases/AudioDevices.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Call.swift
+++ b/UseCases/Call.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Call.swift
+++ b/UseCases/Call.swift
@@ -2,8 +2,8 @@
 //  Call.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallEventTarget.swift
+++ b/UseCases/CallEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallEventTarget.swift
+++ b/UseCases/CallEventTarget.swift
@@ -2,8 +2,8 @@
 //  CallEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistories.swift
+++ b/UseCases/CallHistories.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistories.swift
+++ b/UseCases/CallHistories.swift
@@ -2,8 +2,8 @@
 //  CallHistories.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistory.swift
+++ b/UseCases/CallHistory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistory.swift
+++ b/UseCases/CallHistory.swift
@@ -2,8 +2,8 @@
 //  CallHistory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryCallEventTarget.swift
+++ b/UseCases/CallHistoryCallEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryCallEventTarget.swift
+++ b/UseCases/CallHistoryCallEventTarget.swift
@@ -2,8 +2,8 @@
 //  CallHistoryCallEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryEventTarget.swift
+++ b/UseCases/CallHistoryEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryEventTarget.swift
+++ b/UseCases/CallHistoryEventTarget.swift
@@ -2,8 +2,8 @@
 //  CallHistoryEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecord.swift
+++ b/UseCases/CallHistoryRecord.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecord.swift
+++ b/UseCases/CallHistoryRecord.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecord.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordAddUseCase.swift
+++ b/UseCases/CallHistoryRecordAddUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordAddUseCase.swift
+++ b/UseCases/CallHistoryRecordAddUseCase.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordAddUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordAddUseCaseFactory.swift
+++ b/UseCases/CallHistoryRecordAddUseCaseFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordAddUseCaseFactory.swift
+++ b/UseCases/CallHistoryRecordAddUseCaseFactory.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordAddUseCaseFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordRemoveAllUseCase.swift
+++ b/UseCases/CallHistoryRecordRemoveAllUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordRemoveAllUseCase.swift
+++ b/UseCases/CallHistoryRecordRemoveAllUseCase.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordRemoveAllUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordRemoveUseCase.swift
+++ b/UseCases/CallHistoryRecordRemoveUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordRemoveUseCase.swift
+++ b/UseCases/CallHistoryRecordRemoveUseCase.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordRemoveUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordsGetUseCase.swift
+++ b/UseCases/CallHistoryRecordsGetUseCase.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordsGetUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/CallHistoryRecordsGetUseCase.swift
+++ b/UseCases/CallHistoryRecordsGetUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ConditionalMusicPlayer.swift
+++ b/UseCases/ConditionalMusicPlayer.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ConditionalMusicPlayer.swift
+++ b/UseCases/ConditionalMusicPlayer.swift
@@ -2,8 +2,8 @@
 //  ConditionalMusicPlayer.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ConditionalRingtonePlaybackUseCase.swift
+++ b/UseCases/ConditionalRingtonePlaybackUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ConditionalRingtonePlaybackUseCase.swift
+++ b/UseCases/ConditionalRingtonePlaybackUseCase.swift
@@ -2,8 +2,8 @@
 //  ConditionalRingtonePlaybackUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Contact.swift
+++ b/UseCases/Contact.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Contact.swift
+++ b/UseCases/Contact.swift
@@ -2,8 +2,8 @@
 //  Contact.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ContactAddress.swift
+++ b/UseCases/ContactAddress.swift
@@ -2,8 +2,8 @@
 //  ContactAddress.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ContactAddress.swift
+++ b/UseCases/ContactAddress.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ContactCallHistoryRecord.swift
+++ b/UseCases/ContactCallHistoryRecord.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ContactCallHistoryRecord.swift
+++ b/UseCases/ContactCallHistoryRecord.swift
@@ -2,8 +2,8 @@
 //  ContactCallHistoryRecord.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ContactCallHistoryRecordsGetUseCase.swift
+++ b/UseCases/ContactCallHistoryRecordsGetUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ContactCallHistoryRecordsGetUseCase.swift
+++ b/UseCases/ContactCallHistoryRecordsGetUseCase.swift
@@ -2,8 +2,8 @@
 //  ContactCallHistoryRecordsGetUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DefaultCallHistories.swift
+++ b/UseCases/DefaultCallHistories.swift
@@ -2,8 +2,8 @@
 //  DefaultCallHistories.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DefaultCallHistories.swift
+++ b/UseCases/DefaultCallHistories.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DefaultRingtonePlaybackUseCase.swift
+++ b/UseCases/DefaultRingtonePlaybackUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DefaultRingtonePlaybackUseCase.swift
+++ b/UseCases/DefaultRingtonePlaybackUseCase.swift
@@ -2,8 +2,8 @@
 //  DefaultRingtonePlaybackUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DefaultSoundPlaybackUseCase.swift
+++ b/UseCases/DefaultSoundPlaybackUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DefaultSoundPlaybackUseCase.swift
+++ b/UseCases/DefaultSoundPlaybackUseCase.swift
@@ -2,8 +2,8 @@
 //  DefaultSoundPlaybackUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DelayingUserAgentSoundIOSelectionUseCase.swift
+++ b/UseCases/DelayingUserAgentSoundIOSelectionUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DelayingUserAgentSoundIOSelectionUseCase.swift
+++ b/UseCases/DelayingUserAgentSoundIOSelectionUseCase.swift
@@ -2,8 +2,8 @@
 //  DelayingUserAgentSoundIOSelectionUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DomainUserAgentAudioDeviceExtension.swift
+++ b/UseCases/DomainUserAgentAudioDeviceExtension.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/DomainUserAgentAudioDeviceExtension.swift
+++ b/UseCases/DomainUserAgentAudioDeviceExtension.swift
@@ -2,8 +2,8 @@
 //  DomainUserAgentAudioDeviceExtension.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/KeyValueSettings.swift
+++ b/UseCases/KeyValueSettings.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/KeyValueSettings.swift
+++ b/UseCases/KeyValueSettings.swift
@@ -2,8 +2,8 @@
 //  KeyValueSettings.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/LabeledContactAddress.swift
+++ b/UseCases/LabeledContactAddress.swift
@@ -2,8 +2,8 @@
 //  LabeledContactAddress.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/LabeledContactAddress.swift
+++ b/UseCases/LabeledContactAddress.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/MusicPlayer.h
+++ b/UseCases/MusicPlayer.h
@@ -2,8 +2,8 @@
 //  MusicPlayer.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/MusicPlayer.h
+++ b/UseCases/MusicPlayer.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/MusicPlayerSettings.swift
+++ b/UseCases/MusicPlayerSettings.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/MusicPlayerSettings.swift
+++ b/UseCases/MusicPlayerSettings.swift
@@ -2,8 +2,8 @@
 //  MusicPlayerSettings.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NSString+Analyzing.swift
+++ b/UseCases/NSString+Analyzing.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NSString+Analyzing.swift
+++ b/UseCases/NSString+Analyzing.swift
@@ -2,8 +2,8 @@
 //  NSString+Analyzing.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NotifyingCallHistory.swift
+++ b/UseCases/NotifyingCallHistory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NotifyingCallHistory.swift
+++ b/UseCases/NotifyingCallHistory.swift
@@ -2,8 +2,8 @@
 //  NotifyingCallHistory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NullCallHistoryEventTarget.swift
+++ b/UseCases/NullCallHistoryEventTarget.swift
@@ -2,8 +2,8 @@
 //  NullCallHistoryEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NullCallHistoryEventTarget.swift
+++ b/UseCases/NullCallHistoryEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NullSoundEventTarget.swift
+++ b/UseCases/NullSoundEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NullSoundEventTarget.swift
+++ b/UseCases/NullSoundEventTarget.swift
@@ -2,8 +2,8 @@
 //  NullSoundEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NullThrowingUseCase.swift
+++ b/UseCases/NullThrowingUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/NullThrowingUseCase.swift
+++ b/UseCases/NullThrowingUseCase.swift
@@ -2,8 +2,8 @@
 //  NullThrowingUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PersistentCallHistory.swift
+++ b/UseCases/PersistentCallHistory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PersistentCallHistory.swift
+++ b/UseCases/PersistentCallHistory.swift
@@ -2,8 +2,8 @@
 //  PersistentCallHistory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PreferredSoundIO.swift
+++ b/UseCases/PreferredSoundIO.swift
@@ -2,8 +2,8 @@
 //  PreferredSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PreferredSoundIO.swift
+++ b/UseCases/PreferredSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PresentationSoundIO.swift
+++ b/UseCases/PresentationSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PresentationSoundIO.swift
+++ b/UseCases/PresentationSoundIO.swift
@@ -2,8 +2,8 @@
 //  PresentationSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Product.swift
+++ b/UseCases/Product.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Product.swift
+++ b/UseCases/Product.swift
@@ -2,8 +2,8 @@
 //  Product.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductPurchaseUseCase.swift
+++ b/UseCases/ProductPurchaseUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductPurchaseUseCase.swift
+++ b/UseCases/ProductPurchaseUseCase.swift
@@ -2,8 +2,8 @@
 //  ProductPurchaseUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Products.swift
+++ b/UseCases/Products.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Products.swift
+++ b/UseCases/Products.swift
@@ -2,8 +2,8 @@
 //  Products.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductsEventTarget.swift
+++ b/UseCases/ProductsEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductsEventTarget.swift
+++ b/UseCases/ProductsEventTarget.swift
@@ -2,8 +2,8 @@
 //  ProductsEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductsEventTargets.swift
+++ b/UseCases/ProductsEventTargets.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductsEventTargets.swift
+++ b/UseCases/ProductsEventTargets.swift
@@ -2,8 +2,8 @@
 //  ProductsEventTargets.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductsFetchUseCase.swift
+++ b/UseCases/ProductsFetchUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ProductsFetchUseCase.swift
+++ b/UseCases/ProductsFetchUseCase.swift
@@ -2,8 +2,8 @@
 //  ProductsFetchUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PropertyListStorage.swift
+++ b/UseCases/PropertyListStorage.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PropertyListStorage.swift
+++ b/UseCases/PropertyListStorage.swift
@@ -2,8 +2,8 @@
 //  PropertyListStorage.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseCheckUseCase.swift
+++ b/UseCases/PurchaseCheckUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseCheckUseCase.swift
+++ b/UseCases/PurchaseCheckUseCase.swift
@@ -2,8 +2,8 @@
 //  PurchaseCheckUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseReminderSettings.swift
+++ b/UseCases/PurchaseReminderSettings.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseReminderSettings.swift
+++ b/UseCases/PurchaseReminderSettings.swift
@@ -2,8 +2,8 @@
 //  PurchaseReminderSettings.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseReminderUseCase.swift
+++ b/UseCases/PurchaseReminderUseCase.swift
@@ -2,8 +2,8 @@
 //  PurchaseReminderUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseReminderUseCase.swift
+++ b/UseCases/PurchaseReminderUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseRestorationUseCase.swift
+++ b/UseCases/PurchaseRestorationUseCase.swift
@@ -2,8 +2,8 @@
 //  PurchaseRestorationUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/PurchaseRestorationUseCase.swift
+++ b/UseCases/PurchaseRestorationUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Receipt.swift
+++ b/UseCases/Receipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Receipt.swift
+++ b/UseCases/Receipt.swift
@@ -2,8 +2,8 @@
 //  Receipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ReceiptRefreshUseCase.swift
+++ b/UseCases/ReceiptRefreshUseCase.swift
@@ -2,8 +2,8 @@
 //  ReceiptRefreshUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ReceiptRefreshUseCase.swift
+++ b/UseCases/ReceiptRefreshUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ReceiptValidatingStoreEventTarget.swift
+++ b/UseCases/ReceiptValidatingStoreEventTarget.swift
@@ -2,8 +2,8 @@
 //  ReceiptValidatingStoreEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ReceiptValidatingStoreEventTarget.swift
+++ b/UseCases/ReceiptValidatingStoreEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RepeatingSound.swift
+++ b/UseCases/RepeatingSound.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RepeatingSound.swift
+++ b/UseCases/RepeatingSound.swift
@@ -2,8 +2,8 @@
 //  RepeatingSound.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Ringtone.swift
+++ b/UseCases/Ringtone.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Ringtone.swift
+++ b/UseCases/Ringtone.swift
@@ -2,8 +2,8 @@
 //  Ringtone.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RingtoneFactory.swift
+++ b/UseCases/RingtoneFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RingtoneFactory.swift
+++ b/UseCases/RingtoneFactory.swift
@@ -2,8 +2,8 @@
 //  RingtoneFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RingtoneOutputUpdateUseCase.swift
+++ b/UseCases/RingtoneOutputUpdateUseCase.swift
@@ -2,8 +2,8 @@
 //  RingtoneOutputUpdateUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RingtoneOutputUpdateUseCase.swift
+++ b/UseCases/RingtoneOutputUpdateUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RingtonePlaybackUseCase.swift
+++ b/UseCases/RingtonePlaybackUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/RingtonePlaybackUseCase.swift
+++ b/UseCases/RingtonePlaybackUseCase.swift
@@ -2,8 +2,8 @@
 //  RingtonePlaybackUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ServiceAddress.swift
+++ b/UseCases/ServiceAddress.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ServiceAddress.swift
+++ b/UseCases/ServiceAddress.swift
@@ -2,8 +2,8 @@
 //  ServiceAddress.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsKeys.swift
+++ b/UseCases/SettingsKeys.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsKeys.swift
+++ b/UseCases/SettingsKeys.swift
@@ -2,8 +2,8 @@
 //  SettingsKeys.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsRingtoneSoundConfigurationLoadUseCase.swift
+++ b/UseCases/SettingsRingtoneSoundConfigurationLoadUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsRingtoneSoundConfigurationLoadUseCase.swift
+++ b/UseCases/SettingsRingtoneSoundConfigurationLoadUseCase.swift
@@ -2,8 +2,8 @@
 //  SettingsRingtoneSoundConfigurationLoadUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsRingtoneSoundNameSaveUseCase.swift
+++ b/UseCases/SettingsRingtoneSoundNameSaveUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsRingtoneSoundNameSaveUseCase.swift
+++ b/UseCases/SettingsRingtoneSoundNameSaveUseCase.swift
@@ -2,8 +2,8 @@
 //  SettingsRingtoneSoundNameSaveUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsSoundIO.swift
+++ b/UseCases/SettingsSoundIO.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsSoundIO.swift
+++ b/UseCases/SettingsSoundIO.swift
@@ -2,8 +2,8 @@
 //  SettingsSoundIO.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsSoundIOLoadUseCase.swift
+++ b/UseCases/SettingsSoundIOLoadUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsSoundIOLoadUseCase.swift
+++ b/UseCases/SettingsSoundIOLoadUseCase.swift
@@ -2,8 +2,8 @@
 //  SettingsSoundIOLoadUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsSoundIOSaveUseCase.swift
+++ b/UseCases/SettingsSoundIOSaveUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SettingsSoundIOSaveUseCase.swift
+++ b/UseCases/SettingsSoundIOSaveUseCase.swift
@@ -2,8 +2,8 @@
 //  SettingsSoundIOSaveUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SimpleCall.swift
+++ b/UseCases/SimpleCall.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SimpleCall.swift
+++ b/UseCases/SimpleCall.swift
@@ -2,8 +2,8 @@
 //  SimpleCall.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SimpleMusicPlayerSettings.swift
+++ b/UseCases/SimpleMusicPlayerSettings.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SimpleMusicPlayerSettings.swift
+++ b/UseCases/SimpleMusicPlayerSettings.swift
@@ -2,8 +2,8 @@
 //  SimpleMusicPlayerSettings.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Sound.swift
+++ b/UseCases/Sound.swift
@@ -2,8 +2,8 @@
 //  Sound.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Sound.swift
+++ b/UseCases/Sound.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundConfiguration.swift
+++ b/UseCases/SoundConfiguration.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundConfiguration.swift
+++ b/UseCases/SoundConfiguration.swift
@@ -2,8 +2,8 @@
 //  SoundConfiguration.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundConfigurationLoadUseCase.swift
+++ b/UseCases/SoundConfigurationLoadUseCase.swift
@@ -2,8 +2,8 @@
 //  SoundConfigurationLoadUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundConfigurationLoadUseCase.swift
+++ b/UseCases/SoundConfigurationLoadUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundEventTarget.swift
+++ b/UseCases/SoundEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundEventTarget.swift
+++ b/UseCases/SoundEventTarget.swift
@@ -2,8 +2,8 @@
 //  SoundEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundFactory.swift
+++ b/UseCases/SoundFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundFactory.swift
+++ b/UseCases/SoundFactory.swift
@@ -2,8 +2,8 @@
 //  SoundFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundPlaybackUseCase.swift
+++ b/UseCases/SoundPlaybackUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SoundPlaybackUseCase.swift
+++ b/UseCases/SoundPlaybackUseCase.swift
@@ -2,8 +2,8 @@
 //  SoundPlaybackUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Store.swift
+++ b/UseCases/Store.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Store.swift
+++ b/UseCases/Store.swift
@@ -2,8 +2,8 @@
 //  Store.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/StoreEventTarget.swift
+++ b/UseCases/StoreEventTarget.swift
@@ -2,8 +2,8 @@
 //  StoreEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/StoreEventTarget.swift
+++ b/UseCases/StoreEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/StoreUseCaseFactory.swift
+++ b/UseCases/StoreUseCaseFactory.swift
@@ -2,8 +2,8 @@
 //  StoreUseCaseFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/StoreUseCaseFactory.swift
+++ b/UseCases/StoreUseCaseFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SystemAudioDeviceRepository.swift
+++ b/UseCases/SystemAudioDeviceRepository.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SystemAudioDeviceRepository.swift
+++ b/UseCases/SystemAudioDeviceRepository.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDeviceRepository.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SystemAudioDevicesChangeEventTarget.swift
+++ b/UseCases/SystemAudioDevicesChangeEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SystemAudioDevicesChangeEventTarget.swift
+++ b/UseCases/SystemAudioDevicesChangeEventTarget.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevicesChangeEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SystemAudioDevicesChangeEventTargets.swift
+++ b/UseCases/SystemAudioDevicesChangeEventTargets.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/SystemAudioDevicesChangeEventTargets.swift
+++ b/UseCases/SystemAudioDevicesChangeEventTargets.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevicesChangeEventTargets.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ThrowingUseCase.swift
+++ b/UseCases/ThrowingUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/ThrowingUseCase.swift
+++ b/UseCases/ThrowingUseCase.swift
@@ -2,8 +2,8 @@
 //  ThrowingUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Timer.swift
+++ b/UseCases/Timer.swift
@@ -2,8 +2,8 @@
 //  Timer.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/Timer.swift
+++ b/UseCases/Timer.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/TimerFactory.swift
+++ b/UseCases/TimerFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/TimerFactory.swift
+++ b/UseCases/TimerFactory.swift
@@ -2,8 +2,8 @@
 //  TimerFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/TruncatingCallHistory.swift
+++ b/UseCases/TruncatingCallHistory.swift
@@ -2,8 +2,8 @@
 //  TruncatingCallHistory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/TruncatingCallHistory.swift
+++ b/UseCases/TruncatingCallHistory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/URI.swift
+++ b/UseCases/URI.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/URI.swift
+++ b/UseCases/URI.swift
@@ -2,8 +2,8 @@
 //  URI.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCase.swift
+++ b/UseCases/UseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCase.swift
+++ b/UseCases/UseCase.swift
@@ -2,8 +2,8 @@
 //  UseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCaseFactory.swift
+++ b/UseCases/UseCaseFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCaseFactory.swift
+++ b/UseCases/UseCaseFactory.swift
@@ -2,8 +2,8 @@
 //  UseCaseFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCases.h
+++ b/UseCases/UseCases.h
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCases.h
+++ b/UseCases/UseCases.h
@@ -2,8 +2,8 @@
 //  UseCases.h
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCasesError.swift
+++ b/UseCases/UseCasesError.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UseCasesError.swift
+++ b/UseCases/UseCasesError.swift
@@ -2,8 +2,8 @@
 //  UseCasesError.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgent.swift
+++ b/UseCases/UserAgent.swift
@@ -2,8 +2,8 @@
 //  UserAgent.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgent.swift
+++ b/UseCases/UserAgent.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentAudioDevice.swift
+++ b/UseCases/UserAgentAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentAudioDevice.swift
+++ b/UseCases/UserAgentAudioDevice.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentAudioDeviceUpdateUseCase.swift
+++ b/UseCases/UserAgentAudioDeviceUpdateUseCase.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDeviceUpdateUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentAudioDeviceUpdateUseCase.swift
+++ b/UseCases/UserAgentAudioDeviceUpdateUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentEventTarget.swift
+++ b/UseCases/UserAgentEventTarget.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentEventTarget.swift
+++ b/UseCases/UserAgentEventTarget.swift
@@ -2,8 +2,8 @@
 //  UserAgentEventTarget.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentEventTargets.swift
+++ b/UseCases/UserAgentEventTargets.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentEventTargets.swift
+++ b/UseCases/UserAgentEventTargets.swift
@@ -2,8 +2,8 @@
 //  UserAgentEventTargets.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentSoundIOSelectionUseCase.swift
+++ b/UseCases/UserAgentSoundIOSelectionUseCase.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCases/UserAgentSoundIOSelectionUseCase.swift
+++ b/UseCases/UserAgentSoundIOSelectionUseCase.swift
@@ -2,8 +2,8 @@
 //  UserAgentSoundIOSelectionUseCase.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallEventTargetSpy.swift
+++ b/UseCasesTestDoubles/CallEventTargetSpy.swift
@@ -2,8 +2,8 @@
 //  CallEventTargetSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallEventTargetSpy.swift
+++ b/UseCasesTestDoubles/CallEventTargetSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryEventTargetSpy.swift
+++ b/UseCasesTestDoubles/CallHistoryEventTargetSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryEventTargetSpy.swift
+++ b/UseCasesTestDoubles/CallHistoryEventTargetSpy.swift
@@ -2,8 +2,8 @@
 //  CallHistoryEventTargetSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryFactorySpy.swift
+++ b/UseCasesTestDoubles/CallHistoryFactorySpy.swift
@@ -2,8 +2,8 @@
 //  CallHistoryFactorySpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryFactorySpy.swift
+++ b/UseCasesTestDoubles/CallHistoryFactorySpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryRecordAddUseCaseFactoryStub.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordAddUseCaseFactoryStub.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryRecordAddUseCaseFactoryStub.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordAddUseCaseFactoryStub.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordAddUseCaseFactoryStub.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryRecordTestFactory.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordTestFactory.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryRecordTestFactory.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordTestFactory.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordTestFactory.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryRecordsGetUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordsGetUseCaseOutputSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/CallHistoryRecordsGetUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordsGetUseCaseOutputSpy.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordsGetUseCaseOutputSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ConditionalRingtonePlaybackUseCaseTestDelegate.swift
+++ b/UseCasesTestDoubles/ConditionalRingtonePlaybackUseCaseTestDelegate.swift
@@ -2,8 +2,8 @@
 //  ConditionalRingtonePlaybackUseCaseTestDelegate.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ConditionalRingtonePlaybackUseCaseTestDelegate.swift
+++ b/UseCasesTestDoubles/ConditionalRingtonePlaybackUseCaseTestDelegate.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ContactCallHistoryRecordsGetUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/ContactCallHistoryRecordsGetUseCaseOutputSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ContactCallHistoryRecordsGetUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/ContactCallHistoryRecordsGetUseCaseOutputSpy.swift
@@ -2,8 +2,8 @@
 //  ContactCallHistoryRecordsGetUseCaseOutputSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/DisabledAccountsStub.swift
+++ b/UseCasesTestDoubles/DisabledAccountsStub.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/DisabledAccountsStub.swift
+++ b/UseCasesTestDoubles/DisabledAccountsStub.swift
@@ -2,8 +2,8 @@
 //  DisabledAccountsStub.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/EnabledAccountsStub.swift
+++ b/UseCasesTestDoubles/EnabledAccountsStub.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/EnabledAccountsStub.swift
+++ b/UseCasesTestDoubles/EnabledAccountsStub.swift
@@ -2,8 +2,8 @@
 //  EnabledAccountsStub.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/FailingFetchProductsFake.swift
+++ b/UseCasesTestDoubles/FailingFetchProductsFake.swift
@@ -2,8 +2,8 @@
 //  FailingFetchProductsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/FailingFetchProductsFake.swift
+++ b/UseCasesTestDoubles/FailingFetchProductsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/InvalidReceipt.swift
+++ b/UseCasesTestDoubles/InvalidReceipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/InvalidReceipt.swift
+++ b/UseCasesTestDoubles/InvalidReceipt.swift
@@ -2,8 +2,8 @@
 //  InvalidReceipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/MemoryPropertyListStorage.swift
+++ b/UseCasesTestDoubles/MemoryPropertyListStorage.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/MemoryPropertyListStorage.swift
+++ b/UseCasesTestDoubles/MemoryPropertyListStorage.swift
@@ -2,8 +2,8 @@
 //  MemoryPropertyListStorage.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/MusicPlayerSettingsFake.swift
+++ b/UseCasesTestDoubles/MusicPlayerSettingsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/MusicPlayerSettingsFake.swift
+++ b/UseCasesTestDoubles/MusicPlayerSettingsFake.swift
@@ -2,8 +2,8 @@
 //  MusicPlayerSettingsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/MusicPlayerSpy.swift
+++ b/UseCasesTestDoubles/MusicPlayerSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/MusicPlayerSpy.swift
+++ b/UseCasesTestDoubles/MusicPlayerSpy.swift
@@ -2,8 +2,8 @@
 //  MusicPlayerSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/NoActivePurchasesReceipt.swift
+++ b/UseCasesTestDoubles/NoActivePurchasesReceipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/NoActivePurchasesReceipt.swift
+++ b/UseCasesTestDoubles/NoActivePurchasesReceipt.swift
@@ -2,8 +2,8 @@
 //  NoActivePurchasesReceipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ProductsEventTargetSpy.swift
+++ b/UseCasesTestDoubles/ProductsEventTargetSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ProductsEventTargetSpy.swift
+++ b/UseCasesTestDoubles/ProductsEventTargetSpy.swift
@@ -2,8 +2,8 @@
 //  ProductsEventTargetSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ProductsFetchUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/ProductsFetchUseCaseOutputSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ProductsFetchUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/ProductsFetchUseCaseOutputSpy.swift
@@ -2,8 +2,8 @@
 //  ProductsFetchUseCaseOutputSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/PurchaseCheckUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/PurchaseCheckUseCaseOutputSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/PurchaseCheckUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/PurchaseCheckUseCaseOutputSpy.swift
@@ -2,8 +2,8 @@
 //  PurchaseCheckUseCaseOutputSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/PurchaseReminderUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/PurchaseReminderUseCaseOutputSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/PurchaseReminderUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/PurchaseReminderUseCaseOutputSpy.swift
@@ -2,8 +2,8 @@
 //  PurchaseReminderUseCaseOutputSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/RingtoneFactorySpy.swift
+++ b/UseCasesTestDoubles/RingtoneFactorySpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/RingtoneFactorySpy.swift
+++ b/UseCasesTestDoubles/RingtoneFactorySpy.swift
@@ -2,8 +2,8 @@
 //  RingtoneFactorySpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/RingtonePlaybackUseCaseSpy.swift
+++ b/UseCasesTestDoubles/RingtonePlaybackUseCaseSpy.swift
@@ -2,8 +2,8 @@
 //  RingtonePlaybackUseCaseSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/RingtonePlaybackUseCaseSpy.swift
+++ b/UseCasesTestDoubles/RingtonePlaybackUseCaseSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/RingtoneSpy.swift
+++ b/UseCasesTestDoubles/RingtoneSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/RingtoneSpy.swift
+++ b/UseCasesTestDoubles/RingtoneSpy.swift
@@ -2,8 +2,8 @@
 //  RingtoneSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SettingsFake.swift
+++ b/UseCasesTestDoubles/SettingsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SettingsFake.swift
+++ b/UseCasesTestDoubles/SettingsFake.swift
@@ -2,8 +2,8 @@
 //  SettingsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SettingsRingtoneSoundConfigurationLoadUseCaseSpy.swift
+++ b/UseCasesTestDoubles/SettingsRingtoneSoundConfigurationLoadUseCaseSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SettingsRingtoneSoundConfigurationLoadUseCaseSpy.swift
+++ b/UseCasesTestDoubles/SettingsRingtoneSoundConfigurationLoadUseCaseSpy.swift
@@ -2,8 +2,8 @@
 //  SettingsRingtoneSoundConfigurationLoadUseCaseSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SettingsSoundIOLoadUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/SettingsSoundIOLoadUseCaseOutputSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SettingsSoundIOLoadUseCaseOutputSpy.swift
+++ b/UseCasesTestDoubles/SettingsSoundIOLoadUseCaseOutputSpy.swift
@@ -2,8 +2,8 @@
 //  SettingsSoundIOLoadUseCaseOutputSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SimpleAccount.swift
+++ b/UseCasesTestDoubles/SimpleAccount.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SimpleAccount.swift
+++ b/UseCasesTestDoubles/SimpleAccount.swift
@@ -2,8 +2,8 @@
 //  SimpleAccount.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SimpleProductsFake.swift
+++ b/UseCasesTestDoubles/SimpleProductsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SimpleProductsFake.swift
+++ b/UseCasesTestDoubles/SimpleProductsFake.swift
@@ -2,8 +2,8 @@
 //  SimpleProductsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SoundFactorySpy.swift
+++ b/UseCasesTestDoubles/SoundFactorySpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SoundFactorySpy.swift
+++ b/UseCasesTestDoubles/SoundFactorySpy.swift
@@ -2,8 +2,8 @@
 //  SoundFactorySpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SoundPlaybackUseCaseSpy.swift
+++ b/UseCasesTestDoubles/SoundPlaybackUseCaseSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SoundPlaybackUseCaseSpy.swift
+++ b/UseCasesTestDoubles/SoundPlaybackUseCaseSpy.swift
@@ -2,8 +2,8 @@
 //  SoundPlaybackUseCaseSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SoundSpy.swift
+++ b/UseCasesTestDoubles/SoundSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SoundSpy.swift
+++ b/UseCasesTestDoubles/SoundSpy.swift
@@ -2,8 +2,8 @@
 //  SoundSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/StoreEventTargetSpy.swift
+++ b/UseCasesTestDoubles/StoreEventTargetSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/StoreEventTargetSpy.swift
+++ b/UseCasesTestDoubles/StoreEventTargetSpy.swift
@@ -2,8 +2,8 @@
 //  StoreEventTargetSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/StoreSpy.swift
+++ b/UseCasesTestDoubles/StoreSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/StoreSpy.swift
+++ b/UseCasesTestDoubles/StoreSpy.swift
@@ -2,8 +2,8 @@
 //  StoreSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/StoreUseCaseFactorySpy.swift
+++ b/UseCasesTestDoubles/StoreUseCaseFactorySpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/StoreUseCaseFactorySpy.swift
+++ b/UseCasesTestDoubles/StoreUseCaseFactorySpy.swift
@@ -2,8 +2,8 @@
 //  StoreUseCaseFactorySpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SuccessfulFetchProductsFake.swift
+++ b/UseCasesTestDoubles/SuccessfulFetchProductsFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SuccessfulFetchProductsFake.swift
+++ b/UseCasesTestDoubles/SuccessfulFetchProductsFake.swift
@@ -2,8 +2,8 @@
 //  SuccessfulFetchProductsFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SystemAudioDeviceRepositoryStub.swift
+++ b/UseCasesTestDoubles/SystemAudioDeviceRepositoryStub.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SystemAudioDeviceRepositoryStub.swift
+++ b/UseCasesTestDoubles/SystemAudioDeviceRepositoryStub.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDeviceRepositoryStub.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SystemAudioDevicesChangeEventTargetSpy.swift
+++ b/UseCasesTestDoubles/SystemAudioDevicesChangeEventTargetSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/SystemAudioDevicesChangeEventTargetSpy.swift
+++ b/UseCasesTestDoubles/SystemAudioDevicesChangeEventTargetSpy.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevicesChangeEventTargetSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ThrowingUseCaseSpy.swift
+++ b/UseCasesTestDoubles/ThrowingUseCaseSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ThrowingUseCaseSpy.swift
+++ b/UseCasesTestDoubles/ThrowingUseCaseSpy.swift
@@ -2,8 +2,8 @@
 //  ThrowingUseCaseSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/TimerFactorySpy.swift
+++ b/UseCasesTestDoubles/TimerFactorySpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/TimerFactorySpy.swift
+++ b/UseCasesTestDoubles/TimerFactorySpy.swift
@@ -2,8 +2,8 @@
 //  TimerFactorySpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/TimerSpy.swift
+++ b/UseCasesTestDoubles/TimerSpy.swift
@@ -2,8 +2,8 @@
 //  TimerSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/TimerSpy.swift
+++ b/UseCasesTestDoubles/TimerSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UseCaseFactoryFake.swift
+++ b/UseCasesTestDoubles/UseCaseFactoryFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UseCaseFactoryFake.swift
+++ b/UseCasesTestDoubles/UseCaseFactoryFake.swift
@@ -2,8 +2,8 @@
 //  UseCaseFactoryFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UseCaseFactorySpy.swift
+++ b/UseCasesTestDoubles/UseCaseFactorySpy.swift
@@ -2,8 +2,8 @@
 //  UseCaseFactorySpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UseCaseFactorySpy.swift
+++ b/UseCasesTestDoubles/UseCaseFactorySpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UseCaseSpy.swift
+++ b/UseCasesTestDoubles/UseCaseSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UseCaseSpy.swift
+++ b/UseCasesTestDoubles/UseCaseSpy.swift
@@ -2,8 +2,8 @@
 //  UseCaseSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UserAgentEventTargetSpy.swift
+++ b/UseCasesTestDoubles/UserAgentEventTargetSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UserAgentEventTargetSpy.swift
+++ b/UseCasesTestDoubles/UserAgentEventTargetSpy.swift
@@ -2,8 +2,8 @@
 //  UserAgentEventTargetSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UserAgentSoundIOSelectionUseCaseFake.swift
+++ b/UseCasesTestDoubles/UserAgentSoundIOSelectionUseCaseFake.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UserAgentSoundIOSelectionUseCaseFake.swift
+++ b/UseCasesTestDoubles/UserAgentSoundIOSelectionUseCaseFake.swift
@@ -2,8 +2,8 @@
 //  UserAgentSoundIOSelectionUseCaseFake.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UserAgentSpy.swift
+++ b/UseCasesTestDoubles/UserAgentSpy.swift
@@ -2,8 +2,8 @@
 //  UserAgentSpy.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/UserAgentSpy.swift
+++ b/UseCasesTestDoubles/UserAgentSpy.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ValidReceipt.swift
+++ b/UseCasesTestDoubles/ValidReceipt.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTestDoubles/ValidReceipt.swift
+++ b/UseCasesTestDoubles/ValidReceipt.swift
@@ -2,8 +2,8 @@
 //  ValidReceipt.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryCallEventTargetTests.swift
+++ b/UseCasesTests/CallHistoryCallEventTargetTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryCallEventTargetTests.swift
+++ b/UseCasesTests/CallHistoryCallEventTargetTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryCallEventTargetTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordAddUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordAddUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordAddUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordAddUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordAddUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordRemoveAllUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordRemoveAllUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordRemoveAllUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordRemoveAllUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordRemoveAllUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordRemoveUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordsGetUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordsGetUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/CallHistoryRecordsGetUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordsGetUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  CallHistoryRecordsGetUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ConditionalMusicPlayerTests.swift
+++ b/UseCasesTests/ConditionalMusicPlayerTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ConditionalMusicPlayerTests.swift
+++ b/UseCasesTests/ConditionalMusicPlayerTests.swift
@@ -2,8 +2,8 @@
 //  ConditionalMusicPlayerTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ConditionalRingtonePlaybackUseCaseTests.swift
+++ b/UseCasesTests/ConditionalRingtonePlaybackUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  ConditionalRingtonePlaybackUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ConditionalRingtonePlaybackUseCaseTests.swift
+++ b/UseCasesTests/ConditionalRingtonePlaybackUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ContactCallHistoryRecordsGetUseCaseTests.swift
+++ b/UseCasesTests/ContactCallHistoryRecordsGetUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ContactCallHistoryRecordsGetUseCaseTests.swift
+++ b/UseCasesTests/ContactCallHistoryRecordsGetUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  ContactCallHistoryRecordsGetUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DefaultCallHistoriesTests.swift
+++ b/UseCasesTests/DefaultCallHistoriesTests.swift
@@ -2,8 +2,8 @@
 //  DefaultCallHistoriesTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DefaultCallHistoriesTests.swift
+++ b/UseCasesTests/DefaultCallHistoriesTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DefaultRingtonePlaybackUseCaseTests.swift
+++ b/UseCasesTests/DefaultRingtonePlaybackUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  DefaultRingtonePlaybackUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DefaultRingtonePlaybackUseCaseTests.swift
+++ b/UseCasesTests/DefaultRingtonePlaybackUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DefaultSoundPlaybackUseCaseTests.swift
+++ b/UseCasesTests/DefaultSoundPlaybackUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DefaultSoundPlaybackUseCaseTests.swift
+++ b/UseCasesTests/DefaultSoundPlaybackUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  DefaultSoundPlaybackUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DelayingUserAgentSoundIOSelectionUseCaseTests.swift
+++ b/UseCasesTests/DelayingUserAgentSoundIOSelectionUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  DelayingUserAgentSoundIOSelectionUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/DelayingUserAgentSoundIOSelectionUseCaseTests.swift
+++ b/UseCasesTests/DelayingUserAgentSoundIOSelectionUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/NotifyingCallHistoryTests.swift
+++ b/UseCasesTests/NotifyingCallHistoryTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/NotifyingCallHistoryTests.swift
+++ b/UseCasesTests/NotifyingCallHistoryTests.swift
@@ -2,8 +2,8 @@
 //  NotifyingCallHistoryTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PersistentCallHistoryTests.swift
+++ b/UseCasesTests/PersistentCallHistoryTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PersistentCallHistoryTests.swift
+++ b/UseCasesTests/PersistentCallHistoryTests.swift
@@ -2,8 +2,8 @@
 //  PersistentCallHistoryTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PreferredSoundIOTests.swift
+++ b/UseCasesTests/PreferredSoundIOTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PreferredSoundIOTests.swift
+++ b/UseCasesTests/PreferredSoundIOTests.swift
@@ -2,8 +2,8 @@
 //  PreferredSoundIOTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ProductPurchaseUseCaseTests.swift
+++ b/UseCasesTests/ProductPurchaseUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ProductPurchaseUseCaseTests.swift
+++ b/UseCasesTests/ProductPurchaseUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  ProductPurchaseUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ProductsEventTargetsTests.swift
+++ b/UseCasesTests/ProductsEventTargetsTests.swift
@@ -2,8 +2,8 @@
 //  ProductsEventTargetsTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ProductsEventTargetsTests.swift
+++ b/UseCasesTests/ProductsEventTargetsTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ProductsFetchUseCaseTests.swift
+++ b/UseCasesTests/ProductsFetchUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ProductsFetchUseCaseTests.swift
+++ b/UseCasesTests/ProductsFetchUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  ProductsFetchUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PurchaseCheckUseCaseTests.swift
+++ b/UseCasesTests/PurchaseCheckUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PurchaseCheckUseCaseTests.swift
+++ b/UseCasesTests/PurchaseCheckUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  PurchaseCheckUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PurchaseReminderUseCaseTests.swift
+++ b/UseCasesTests/PurchaseReminderUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PurchaseReminderUseCaseTests.swift
+++ b/UseCasesTests/PurchaseReminderUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  PurchaseReminderUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PurchaseRestorationUseCaseTests.swift
+++ b/UseCasesTests/PurchaseRestorationUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/PurchaseRestorationUseCaseTests.swift
+++ b/UseCasesTests/PurchaseRestorationUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  PurchaseRestorationUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ReceiptValidatingStoreEventTargetTests.swift
+++ b/UseCasesTests/ReceiptValidatingStoreEventTargetTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ReceiptValidatingStoreEventTargetTests.swift
+++ b/UseCasesTests/ReceiptValidatingStoreEventTargetTests.swift
@@ -2,8 +2,8 @@
 //  ReceiptValidatingStoreEventTargetTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/RepeatingSoundTests.swift
+++ b/UseCasesTests/RepeatingSoundTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/RepeatingSoundTests.swift
+++ b/UseCasesTests/RepeatingSoundTests.swift
@@ -2,8 +2,8 @@
 //  RepeatingSoundTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/RingtoneOutputUpdateUseCaseTests.swift
+++ b/UseCasesTests/RingtoneOutputUpdateUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/RingtoneOutputUpdateUseCaseTests.swift
+++ b/UseCasesTests/RingtoneOutputUpdateUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  RingtoneOutputUpdateUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ServiceAddressTests.swift
+++ b/UseCasesTests/ServiceAddressTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/ServiceAddressTests.swift
+++ b/UseCasesTests/ServiceAddressTests.swift
@@ -2,8 +2,8 @@
 //  ServiceAddressTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsRingtoneSoundConfigurationLoadUseCaseTests.swift
+++ b/UseCasesTests/SettingsRingtoneSoundConfigurationLoadUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsRingtoneSoundConfigurationLoadUseCaseTests.swift
+++ b/UseCasesTests/SettingsRingtoneSoundConfigurationLoadUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  SettingsRingtoneSoundConfigurationLoadUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsRingtoneSoundNameSaveUseCaseTests.swift
+++ b/UseCasesTests/SettingsRingtoneSoundNameSaveUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsRingtoneSoundNameSaveUseCaseTests.swift
+++ b/UseCasesTests/SettingsRingtoneSoundNameSaveUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  SettingsRingtoneSoundNameSaveUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsSoundIOLoadUseCaseTests.swift
+++ b/UseCasesTests/SettingsSoundIOLoadUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsSoundIOLoadUseCaseTests.swift
+++ b/UseCasesTests/SettingsSoundIOLoadUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  SettingsSoundIOLoadUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsSoundIOSaveUseCaseTests.swift
+++ b/UseCasesTests/SettingsSoundIOSaveUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SettingsSoundIOSaveUseCaseTests.swift
+++ b/UseCasesTests/SettingsSoundIOSaveUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  SettingsSoundIOSaveUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SimpleMusicPlayerSettingsTests.swift
+++ b/UseCasesTests/SimpleMusicPlayerSettingsTests.swift
@@ -2,8 +2,8 @@
 //  SimpleMusicPlayerSettingsTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SimpleMusicPlayerSettingsTests.swift
+++ b/UseCasesTests/SimpleMusicPlayerSettingsTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift
+++ b/UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift
+++ b/UseCasesTests/SystemAudioDevicesChangeEventTargetsTests.swift
@@ -2,8 +2,8 @@
 //  SystemAudioDevicesChangeEventTargetsTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/TruncatingCallHistoryTests.swift
+++ b/UseCasesTests/TruncatingCallHistoryTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/TruncatingCallHistoryTests.swift
+++ b/UseCasesTests/TruncatingCallHistoryTests.swift
@@ -2,8 +2,8 @@
 //  TruncatingCallHistoryTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentAudioDevice+SystemAudioDevice.swift
+++ b/UseCasesTests/UserAgentAudioDevice+SystemAudioDevice.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentAudioDevice+SystemAudioDevice.swift
+++ b/UseCasesTests/UserAgentAudioDevice+SystemAudioDevice.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDevice+SystemAudioDevice.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentAudioDeviceUpdateUseCaseTests.swift
+++ b/UseCasesTests/UserAgentAudioDeviceUpdateUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  UserAgentAudioDeviceUpdateUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentAudioDeviceUpdateUseCaseTests.swift
+++ b/UseCasesTests/UserAgentAudioDeviceUpdateUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentEventTargetsTests.swift
+++ b/UseCasesTests/UserAgentEventTargetsTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentEventTargetsTests.swift
+++ b/UseCasesTests/UserAgentEventTargetsTests.swift
@@ -2,8 +2,8 @@
 //  UserAgentEventTargetsTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentSoundIOSelectionUseCaseTests.swift
+++ b/UseCasesTests/UserAgentSoundIOSelectionUseCaseTests.swift
@@ -2,8 +2,8 @@
 //  UserAgentSoundIOSelectionUseCaseTests.swift
 //  Telephone
 //
-//  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016-2017 64 Characters
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/UseCasesTests/UserAgentSoundIOSelectionUseCaseTests.swift
+++ b/UseCasesTests/UserAgentSoundIOSelectionUseCaseTests.swift
@@ -3,7 +3,7 @@
 //  Telephone
 //
 //  Copyright (c) 2008-2016 Alexey Kuznetsov
-//  Copyright (c) 2016 64 Characters
+//  Copyright (c) 2016-2017 64 Characters
 //
 //  Telephone is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Update copyright info with the current year and use the copyright character instead of (c).

Issue #342 