### PR TITLE
Call history record identifier

### DIFF
--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		8A09E0FA1E79A29D0027A25E /* ReversedCallHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A09E0F91E79A29D0027A25E /* ReversedCallHistory.swift */; };
 		8A0ABBC11EF96C1E0062D3CC /* IdentifierGeneratorStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ABBC01EF96C1E0062D3CC /* IdentifierGeneratorStub.swift */; };
 		8A0ABBC31EF96CD00062D3CC /* IdentifierGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ABBC21EF96CD00062D3CC /* IdentifierGenerator.swift */; };
+		8A0ABBC61EF9775F0062D3CC /* UUIDIdentifierGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ABBC41EF970AE0062D3CC /* UUIDIdentifierGenerator.swift */; };
 		8A0CF81B1EC1F10B0014226A /* IndexedContactMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0CF81A1EC1F10B0014226A /* IndexedContactMatchingTests.swift */; };
 		8A0CF81D1EC1F5400014226A /* IndexedContactMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0CF81C1EC1F5400014226A /* IndexedContactMatching.swift */; };
 		8A0CF81F1EC235690014226A /* ContactMatchingIndexFactorySpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0CF81E1EC235690014226A /* ContactMatchingIndexFactorySpy.swift */; };
@@ -752,6 +753,7 @@
 		8A09E0F91E79A29D0027A25E /* ReversedCallHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReversedCallHistory.swift; sourceTree = "<group>"; };
 		8A0ABBC01EF96C1E0062D3CC /* IdentifierGeneratorStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierGeneratorStub.swift; sourceTree = "<group>"; };
 		8A0ABBC21EF96CD00062D3CC /* IdentifierGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierGenerator.swift; sourceTree = "<group>"; };
+		8A0ABBC41EF970AE0062D3CC /* UUIDIdentifierGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUIDIdentifierGenerator.swift; sourceTree = "<group>"; };
 		8A0CF81A1EC1F10B0014226A /* IndexedContactMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IndexedContactMatchingTests.swift; path = UseCasesTests/IndexedContactMatchingTests.swift; sourceTree = SOURCE_ROOT; };
 		8A0CF81C1EC1F5400014226A /* IndexedContactMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexedContactMatching.swift; sourceTree = "<group>"; };
 		8A0CF81E1EC235690014226A /* ContactMatchingIndexFactorySpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactMatchingIndexFactorySpy.swift; sourceTree = "<group>"; };
@@ -1563,6 +1565,7 @@
 				AA3FABAF1BBC1CCE0064B2C3 /* TelephoneError.swift */,
 				AA32F7F91BC52A2A00FAC228 /* UserDefaultsKeys.h */,
 				AA32F7FA1BC52A2A00FAC228 /* UserDefaultsKeys.m */,
+				8A0ABBC41EF970AE0062D3CC /* UUIDIdentifierGenerator.swift */,
 				8A7292381EDF2B2100338592 /* WaitingThread.swift */,
 				8A1DA8121DF07EA700F5BA40 /* WorkspaceSleepStatus.swift */,
 				8A1DA8141DF07EEE00F5BA40 /* WorkspaceSleepStatusTests.swift */,
@@ -3385,6 +3388,7 @@
 				8AE7063D1D4A4D370060FF4F /* ReceiptXPCGateway.swift in Sources */,
 				8A6D96F01D05937900D9C15B /* NullStoreViewEventTarget.swift in Sources */,
 				8A9175A21CA5A02500354E26 /* PJSUAOnCallTransferStatus.m in Sources */,
+				8A0ABBC61EF9775F0062D3CC /* UUIDIdentifierGenerator.swift in Sources */,
 				AA1019841C490BD300869D01 /* RepeatingSoundFactory.swift in Sources */,
 				AA19CFF51BED148A00991CAA /* DefaultUseCaseFactory.swift in Sources */,
 				AAFA9C3D0EE411BA009A45CB /* AKTelephoneNumberFormatter.m in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		8A0451E61C93308000A08012 /* SoundPlaybackUseCaseSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0451E51C93308000A08012 /* SoundPlaybackUseCaseSpy.swift */; };
 		8A09E0F81E79A2560027A25E /* ReversedCallHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A09E0F71E79A2560027A25E /* ReversedCallHistoryTests.swift */; };
 		8A09E0FA1E79A29D0027A25E /* ReversedCallHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A09E0F91E79A29D0027A25E /* ReversedCallHistory.swift */; };
+		8A0ABBC11EF96C1E0062D3CC /* IdentifierGeneratorStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ABBC01EF96C1E0062D3CC /* IdentifierGeneratorStub.swift */; };
+		8A0ABBC31EF96CD00062D3CC /* IdentifierGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0ABBC21EF96CD00062D3CC /* IdentifierGenerator.swift */; };
 		8A0CF81B1EC1F10B0014226A /* IndexedContactMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0CF81A1EC1F10B0014226A /* IndexedContactMatchingTests.swift */; };
 		8A0CF81D1EC1F5400014226A /* IndexedContactMatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0CF81C1EC1F5400014226A /* IndexedContactMatching.swift */; };
 		8A0CF81F1EC235690014226A /* ContactMatchingIndexFactorySpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A0CF81E1EC235690014226A /* ContactMatchingIndexFactorySpy.swift */; };
@@ -748,6 +750,8 @@
 		8A073BA11DAC445700301E58 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Account.strings; sourceTree = "<group>"; };
 		8A09E0F71E79A2560027A25E /* ReversedCallHistoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReversedCallHistoryTests.swift; path = UseCasesTests/ReversedCallHistoryTests.swift; sourceTree = SOURCE_ROOT; };
 		8A09E0F91E79A29D0027A25E /* ReversedCallHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReversedCallHistory.swift; sourceTree = "<group>"; };
+		8A0ABBC01EF96C1E0062D3CC /* IdentifierGeneratorStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierGeneratorStub.swift; sourceTree = "<group>"; };
+		8A0ABBC21EF96CD00062D3CC /* IdentifierGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifierGenerator.swift; sourceTree = "<group>"; };
 		8A0CF81A1EC1F10B0014226A /* IndexedContactMatchingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IndexedContactMatchingTests.swift; path = UseCasesTests/IndexedContactMatchingTests.swift; sourceTree = SOURCE_ROOT; };
 		8A0CF81C1EC1F5400014226A /* IndexedContactMatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexedContactMatching.swift; sourceTree = "<group>"; };
 		8A0CF81E1EC235690014226A /* ContactMatchingIndexFactorySpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactMatchingIndexFactorySpy.swift; sourceTree = "<group>"; };
@@ -2371,6 +2375,7 @@
 				8AAFE6221EE1C85C00BACC62 /* EnqueuingUseCase.swift */,
 				8AAFE6201EE1C7E200BACC62 /* EnqueuingUseCaseTests.swift */,
 				8A7292241EDDCC9600338592 /* ExecutionQueue.swift */,
+				8A0ABBC21EF96CD00062D3CC /* IdentifierGenerator.swift */,
 				AA32F7FD1BC6908300FAC228 /* KeyValueSettings.swift */,
 				8A46FDBC1DD4A8100022A822 /* NSString+Analyzing.swift */,
 				8ACD2ADD1DD1FEF800E81984 /* PropertyListStorage.swift */,
@@ -2639,6 +2644,7 @@
 				8A9084A31EC6101A002B273A /* ContactMatchingSettingsFake.swift */,
 				8A4B65A71EB0CB7B00F13654 /* ContactMatchingStub.swift */,
 				8A7292401EE01F5900338592 /* ExecutionQueue */,
+				8A0ABBC01EF96C1E0062D3CC /* IdentifierGeneratorStub.swift */,
 				8AA748AA1D7023B5000587DC /* MusicPlayerSettingsFake.swift */,
 				8AA748A81D7022BA000587DC /* MusicPlayerSpy.swift */,
 				8A859A091D2EC71900118A66 /* Products */,
@@ -3581,6 +3587,7 @@
 				8AAFE61D1EE1A2BA00BACC62 /* EnqueuingCallEventTarget.swift in Sources */,
 				AA3B6E821C46B55C0030D410 /* RepeatingSound.swift in Sources */,
 				8A0CF8211EC235D40014226A /* ContactMatchingIndexFactory.swift in Sources */,
+				8A0ABBC31EF96CD00062D3CC /* IdentifierGenerator.swift in Sources */,
 				8AD9A0F91DE7185A000BB2F2 /* CallHistoryRecordsGetUseCase.swift in Sources */,
 				AA3905301BFFDDDA005A8AA3 /* SystemAudioDeviceRepository.swift in Sources */,
 				8A11157E1DEF1620000AC284 /* CallHistoryRecordAddUseCaseFactory.swift in Sources */,
@@ -3803,6 +3810,7 @@
 				AA1019791C48078900869D01 /* RingtoneFactorySpy.swift in Sources */,
 				8A0451E61C93308000A08012 /* SoundPlaybackUseCaseSpy.swift in Sources */,
 				8ADD6A771CE0E704001EDBBA /* ProductsEventTargetSpy.swift in Sources */,
+				8A0ABBC11EF96C1E0062D3CC /* IdentifierGeneratorStub.swift in Sources */,
 				8A0CF81F1EC235690014226A /* ContactMatchingIndexFactorySpy.swift in Sources */,
 				AA7F6D491C0382550064DA3A /* SettingsSoundIOLoadUseCaseOutputSpy.swift in Sources */,
 				8ADB739A1DE86D540032B4C2 /* SimpleAccount.swift in Sources */,

--- a/Telephone/CallHistoryViewController.swift
+++ b/Telephone/CallHistoryViewController.swift
@@ -71,7 +71,7 @@ final class CallHistoryViewController: NSViewController {
         let index = tableView.selectedRow
         makeAlert(recordName: records[index].date).beginSheetModal(for: view.window!) { response in
             if response == NSAlertFirstButtonReturn {
-                self.target?.shouldRemoveRecord(at: index)
+                self.target?.shouldRemoveRecord(withIdentifier: self.records[index].identifier)
             }
         }
     }

--- a/Telephone/CallHistoryViewController.swift
+++ b/Telephone/CallHistoryViewController.swift
@@ -68,10 +68,10 @@ final class CallHistoryViewController: NSViewController {
 
     private func deleteRecord() {
         guard !records.isEmpty else { return }
-        let index = tableView.selectedRow
-        makeAlert(recordName: records[index].date).beginSheetModal(for: view.window!) { response in
+        let record = records[tableView.selectedRow]
+        makeAlert(recordName: record.date).beginSheetModal(for: view.window!) { response in
             if response == NSAlertFirstButtonReturn {
-                self.target?.shouldRemoveRecord(withIdentifier: self.records[index].identifier)
+                self.target?.shouldRemoveRecord(withIdentifier: record.identifier)
             }
         }
     }

--- a/Telephone/CallHistoryViewEventTarget.swift
+++ b/Telephone/CallHistoryViewEventTarget.swift
@@ -37,8 +37,8 @@ final class CallHistoryViewEventTarget: NSObject {
         callMake.make(index: index).execute()
     }
 
-    func shouldRemoveRecord(at index: Int) {
-        recordRemove.make(index: index).execute()
+    func shouldRemoveRecord(withIdentifier identifier: String) {
+        recordRemove.make(identifier: identifier).execute()
     }
 }
 

--- a/Telephone/CallHistoryViewPresenter.swift
+++ b/Telephone/CallHistoryViewPresenter.swift
@@ -38,6 +38,7 @@ extension CallHistoryViewPresenter: ContactCallHistoryRecordsGetUseCaseOutput {
 
     private func makeRecord(from record: ContactCallHistoryRecord) -> PresentationCallHistoryRecord {
         return PresentationCallHistoryRecord(
+            identifier: record.origin.identifier,
             contact: PresentationContact(contact: record.contact, color: contactColor(for: record)),
             date: dateFormatter.string(from: record.origin.date),
             duration: durationFormatter.string(from: TimeInterval(record.origin.duration)) ?? "",

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -181,7 +181,9 @@ final class CompositionRoot: NSObject {
             center: NotificationCenter.default,
             target: EnqueuingCallEventTarget(
                 origin: CallHistoryCallEventTarget(
-                    histories: callHistories, factory: DefaultCallHistoryRecordAddUseCaseFactory()
+                    histories: callHistories,
+                    generator: UUIDIdentifierGenerator(),
+                    factory: DefaultCallHistoryRecordAddUseCaseFactory()
                 ),
                 queue: contactsBackground)
         )

--- a/Telephone/DefaultCallHistoryRecordRemoveUseCaseFactory.swift
+++ b/Telephone/DefaultCallHistoryRecordRemoveUseCaseFactory.swift
@@ -28,6 +28,6 @@ final class DefaultCallHistoryRecordRemoveUseCaseFactory {
 
 extension DefaultCallHistoryRecordRemoveUseCaseFactory: CallHistoryRecordRemoveUseCaseFactory {
     public func make(identifier: String) -> UseCase {
-        return CallHistoryRecordRemoveUseCase(history: history, identifier: identifier)
+        return CallHistoryRecordRemoveUseCase(identifier: identifier, history: history)
     }
 }

--- a/Telephone/DefaultCallHistoryRecordRemoveUseCaseFactory.swift
+++ b/Telephone/DefaultCallHistoryRecordRemoveUseCaseFactory.swift
@@ -27,7 +27,7 @@ final class DefaultCallHistoryRecordRemoveUseCaseFactory {
 }
 
 extension DefaultCallHistoryRecordRemoveUseCaseFactory: CallHistoryRecordRemoveUseCaseFactory {
-    public func make(index: Int) -> UseCase {
-        return CallHistoryRecordRemoveUseCase(history: history, index: index)
+    public func make(identifier: String) -> UseCase {
+        return CallHistoryRecordRemoveUseCase(history: history, identifier: identifier)
     }
 }

--- a/Telephone/PresentationCallHistoryRecord.swift
+++ b/Telephone/PresentationCallHistoryRecord.swift
@@ -20,12 +20,14 @@ import Cocoa
 import UseCases
 
 final class PresentationCallHistoryRecord: NSObject {
+    let identifier: String
     let contact: PresentationContact
     let date: String
     let duration: String
     let isIncoming: Bool
 
-    init(contact: PresentationContact, date: String, duration: String, isIncoming: Bool) {
+    init(identifier: String, contact: PresentationContact, date: String, duration: String, isIncoming: Bool) {
+        self.identifier = identifier
         self.contact = contact
         self.date = date
         self.duration = duration
@@ -40,11 +42,13 @@ extension PresentationCallHistoryRecord {
     }
 
     override var hash: Int {
-        return contact.hash ^ date.hash ^ duration.hash ^ (isIncoming ? 1231 : 1237)
+        return identifier.hash ^ contact.hash ^ date.hash ^ duration.hash ^ (isIncoming ? 1231 : 1237)
     }
 
     private func isEqual(to record: PresentationCallHistoryRecord) -> Bool {
-        return contact == record.contact &&
+        return
+            identifier == record.identifier &&
+            contact == record.contact &&
             date == record.date &&
             duration == record.duration &&
             isIncoming == record.isIncoming

--- a/Telephone/UUIDIdentifierGenerator.swift
+++ b/Telephone/UUIDIdentifierGenerator.swift
@@ -1,0 +1,23 @@
+//
+//  UUIDIdentifierGenerator.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+final class UUIDIdentifierGenerator: IdentifierGenerator {
+    func generate() -> String {
+        return UUID().uuidString
+    }
+}

--- a/TelephoneTests/CallHistoryViewEventTargetTests.swift
+++ b/TelephoneTests/CallHistoryViewEventTargetTests.swift
@@ -79,10 +79,11 @@ final class CallHistoryViewEventTargetTests: XCTestCase {
             recordRemove: factory,
             callMake: CallHistoryCallMakeUseCaseFactorySpy(callMake: UseCaseSpy())
         )
+        let identifier = "any"
 
-        sut.shouldRemoveRecord(at: 2)
+        sut.shouldRemoveRecord(withIdentifier: identifier)
 
-        XCTAssertEqual(factory.invokedIndex, 2)
+        XCTAssertEqual(factory.invokedIdentifier, identifier)
     }
 
     func testExecutesCallHistoryRecordRemoveUseCaseOnShouldRemoveRecord() {
@@ -93,7 +94,7 @@ final class CallHistoryViewEventTargetTests: XCTestCase {
             callMake: CallHistoryCallMakeUseCaseFactorySpy(callMake: UseCaseSpy())
         )
 
-        sut.shouldRemoveRecord(at: 0)
+        sut.shouldRemoveRecord(withIdentifier: "any")
 
         XCTAssertTrue(remove.didCallExecute)
     }

--- a/TelephoneTests/CallHistoryViewPresenterTests.swift
+++ b/TelephoneTests/CallHistoryViewPresenterTests.swift
@@ -46,6 +46,7 @@ final class CallHistoryViewPresenterTests: XCTestCase {
 
     func testContactColorIsRedForMissedCallRecords() {
         let record = CallHistoryRecord(
+            identifier: "any-identifier",
             uri: URI(user: "any-user", host: "any-host", displayName: "any-name"),
             date: Date(),
             duration: 0,

--- a/TelephoneTests/CallHistoryViewPresenterTests.swift
+++ b/TelephoneTests/CallHistoryViewPresenterTests.swift
@@ -99,6 +99,7 @@ private func makeContact(number: Int) -> MatchedContact {
 
 private func makePresentationCallHistoryRecord(contact: MatchedContact, record: CallHistoryRecord) -> PresentationCallHistoryRecord {
     return PresentationCallHistoryRecord(
+        identifier: record.identifier,
         contact: makePresentationContact(contact: contact, color: contactColor(for: record)),
         date: ShortRelativeDateTimeFormatter().string(from: record.date),
         duration: DurationFormatter().string(from: TimeInterval(record.duration))!,

--- a/UseCases/CallHistory.swift
+++ b/UseCases/CallHistory.swift
@@ -23,3 +23,9 @@ public protocol CallHistory: class {
     func removeAll()
     func updateTarget(_ target: CallHistoryEventTarget)
 }
+
+public extension CallHistory {
+    func record(withIdentifier identifier: String) -> CallHistoryRecord? {
+        return self.allRecords.first { $0.identifier == identifier }
+    }
+}

--- a/UseCases/CallHistoryCallEventTarget.swift
+++ b/UseCases/CallHistoryCallEventTarget.swift
@@ -18,10 +18,12 @@
 
 public final class CallHistoryCallEventTarget {
     fileprivate let histories: CallHistories
+    fileprivate let generator: IdentifierGenerator
     fileprivate let factory: CallHistoryRecordAddUseCaseFactory
 
-    public init(histories: CallHistories, factory: CallHistoryRecordAddUseCaseFactory) {
+    public init(histories: CallHistories, generator: IdentifierGenerator, factory: CallHistoryRecordAddUseCaseFactory) {
         self.histories = histories
+        self.generator = generator
         self.factory = factory
     }
 }
@@ -30,7 +32,7 @@ extension CallHistoryCallEventTarget: CallEventTarget {
     public func didDisconnect(_ call: Call) {
         factory.make(
             history: histories.history(withUUID: call.account.uuid),
-            record: CallHistoryRecord(identifier: "123", call: call),
+            record: CallHistoryRecord(identifier: generator.generate(), call: call),
             domain: call.account.domain
         ).execute()
     }

--- a/UseCases/CallHistoryCallEventTarget.swift
+++ b/UseCases/CallHistoryCallEventTarget.swift
@@ -30,7 +30,7 @@ extension CallHistoryCallEventTarget: CallEventTarget {
     public func didDisconnect(_ call: Call) {
         factory.make(
             history: histories.history(withUUID: call.account.uuid),
-            record: CallHistoryRecord(call: call),
+            record: CallHistoryRecord(identifier: "123", call: call),
             domain: call.account.domain
         ).execute()
     }

--- a/UseCases/CallHistoryRecord.swift
+++ b/UseCases/CallHistoryRecord.swift
@@ -62,11 +62,13 @@ extension CallHistoryRecord: Equatable {
 
 extension CallHistoryRecord {
     public init(identifier: String, call: Call) {
-        self.identifier = identifier
-        uri = call.remote
-        date = call.date
-        duration = call.duration
-        isIncoming = call.isIncoming
-        isMissed = call.isMissed
+        self.init(
+            identifier: identifier,
+            uri: call.remote,
+            date: call.date,
+            duration: call.duration,
+            isIncoming: call.isIncoming,
+            isMissed: call.isMissed
+        )
     }
 }

--- a/UseCases/CallHistoryRecord.swift
+++ b/UseCases/CallHistoryRecord.swift
@@ -19,13 +19,16 @@
 import Foundation
 
 public struct CallHistoryRecord {
+    public let identifier: String
     public let uri: URI
     public let date: Date
     public let duration: Int
     public let isIncoming: Bool
     public let isMissed: Bool
 
-    public init(uri: URI, date: Date, duration: Int, isIncoming: Bool, isMissed: Bool) {
+    public init(identifier: String, uri: URI, date: Date, duration: Int, isIncoming: Bool, isMissed: Bool) {
+        precondition(!identifier.isEmpty)
+        self.identifier = identifier
         self.uri = uri
         self.date = date
         self.duration = duration
@@ -35,6 +38,7 @@ public struct CallHistoryRecord {
 
     public func removingHost() -> CallHistoryRecord {
         return CallHistoryRecord(
+            identifier: identifier,
             uri: URI(user: uri.user, host: "", displayName: uri.displayName),
             date: date,
             duration: duration,
@@ -47,6 +51,7 @@ public struct CallHistoryRecord {
 extension CallHistoryRecord: Equatable {
     public static func ==(lhs: CallHistoryRecord, rhs: CallHistoryRecord) -> Bool {
         return
+            lhs.identifier == rhs.identifier &&
             lhs.uri == rhs.uri &&
             lhs.date == rhs.date &&
             lhs.duration == rhs.duration &&
@@ -56,7 +61,8 @@ extension CallHistoryRecord: Equatable {
 }
 
 extension CallHistoryRecord {
-    public init(call: Call) {
+    public init(identifier: String, call: Call) {
+        self.identifier = identifier
         uri = call.remote
         date = call.date
         duration = call.duration

--- a/UseCases/CallHistoryRecordRemoveUseCase.swift
+++ b/UseCases/CallHistoryRecordRemoveUseCase.swift
@@ -18,16 +18,18 @@
 
 public final class CallHistoryRecordRemoveUseCase {
     fileprivate let history: CallHistory
-    fileprivate let index: Int
+    fileprivate let identifier: String
 
-    public init(history: CallHistory, index: Int) {
+    public init(history: CallHistory, identifier: String) {
         self.history = history
-        self.index = index
+        self.identifier = identifier
     }
 }
 
 extension CallHistoryRecordRemoveUseCase: UseCase {
     public func execute() {
-        history.remove(history.allRecords[index])
+        if let record = history.record(withIdentifier: identifier) {
+            history.remove(record)
+        }
     }
 }

--- a/UseCases/CallHistoryRecordRemoveUseCase.swift
+++ b/UseCases/CallHistoryRecordRemoveUseCase.swift
@@ -17,12 +17,12 @@
 //
 
 public final class CallHistoryRecordRemoveUseCase {
-    fileprivate let history: CallHistory
     fileprivate let identifier: String
+    fileprivate let history: CallHistory
 
-    public init(history: CallHistory, identifier: String) {
-        self.history = history
+    public init(identifier: String, history: CallHistory) {
         self.identifier = identifier
+        self.history = history
     }
 }
 

--- a/UseCases/CallHistoryRecordRemoveUseCaseFactory.swift
+++ b/UseCases/CallHistoryRecordRemoveUseCaseFactory.swift
@@ -17,5 +17,5 @@
 //
 
 public protocol CallHistoryRecordRemoveUseCaseFactory {
-    func make(index: Int) -> UseCase
+    func make(identifier: String) -> UseCase
 }

--- a/UseCases/EnqueueingCallHistoryRecordRemoveUseCaseFactory.swift
+++ b/UseCases/EnqueueingCallHistoryRecordRemoveUseCaseFactory.swift
@@ -27,7 +27,7 @@ public final class EnqueueingCallHistoryRecordRemoveUseCaseFactory {
 }
 
 extension EnqueueingCallHistoryRecordRemoveUseCaseFactory: CallHistoryRecordRemoveUseCaseFactory {
-    public func make(index: Int) -> UseCase {
-        return EnqueuingUseCase(origin: origin.make(index: index), queue: queue)
+    public func make(identifier: String) -> UseCase {
+        return EnqueuingUseCase(origin: origin.make(identifier: identifier), queue: queue)
     }
 }

--- a/UseCases/IdentifierGenerator.swift
+++ b/UseCases/IdentifierGenerator.swift
@@ -1,0 +1,21 @@
+//
+//  IdentifierGenerator.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+public protocol IdentifierGenerator {
+    func generate() -> String
+}

--- a/UseCases/PersistentCallHistory.swift
+++ b/UseCases/PersistentCallHistory.swift
@@ -75,6 +75,7 @@ extension PersistentCallHistory: CallHistory {
 
 private extension CallHistoryRecord {
     init(dictionary: [String: Any]) {
+        identifier = dictionary[Keys.identifier] as! String
         let user = dictionary[Keys.user] as? String ?? ""
         let host = dictionary[Keys.host] as? String ?? ""
         let name = dictionary[Keys.name] as? String ?? ""
@@ -89,6 +90,7 @@ private extension CallHistoryRecord {
 private func dictionaries(from records: [CallHistoryRecord]) -> [[String: Any]] {
     return records.map {
         [
+            Keys.identifier: $0.identifier,
             Keys.user: $0.uri.user,
             Keys.host: $0.uri.host,
             Keys.name: $0.uri.displayName,
@@ -101,6 +103,7 @@ private func dictionaries(from records: [CallHistoryRecord]) -> [[String: Any]] 
 }
 
 private enum Keys {
+    static let identifier = "identifier"
     static let user = "user"
     static let host = "host"
     static let name = "name"

--- a/UseCases/PersistentCallHistory.swift
+++ b/UseCases/PersistentCallHistory.swift
@@ -75,40 +75,33 @@ extension PersistentCallHistory: CallHistory {
 
 private extension CallHistoryRecord {
     init(dictionary: [String: Any]) {
-        identifier = dictionary[Keys.identifier] as! String
-        let user = dictionary[Keys.user] as? String ?? ""
-        let host = dictionary[Keys.host] as? String ?? ""
-        let name = dictionary[Keys.name] as? String ?? ""
+        identifier = dictionary[Keys.identifier.rawValue] as! String
+        let user = dictionary[Keys.user.rawValue] as? String ?? ""
+        let host = dictionary[Keys.host.rawValue] as? String ?? ""
+        let name = dictionary[Keys.name.rawValue] as? String ?? ""
         uri = URI(user: user, host: host, displayName: name)
-        date = dictionary[Keys.date] as? Date ?? Date.distantPast
-        duration = dictionary[Keys.duration] as? Int ?? 0
-        isIncoming = dictionary[Keys.incoming] as? Bool ?? false
-        isMissed = dictionary[Keys.missed] as? Bool ?? false
+        date = dictionary[Keys.date.rawValue] as? Date ?? Date.distantPast
+        duration = dictionary[Keys.duration.rawValue] as? Int ?? 0
+        isIncoming = dictionary[Keys.incoming.rawValue] as? Bool ?? false
+        isMissed = dictionary[Keys.missed.rawValue] as? Bool ?? false
     }
 }
 
 private func dictionaries(from records: [CallHistoryRecord]) -> [[String: Any]] {
     return records.map {
         [
-            Keys.identifier: $0.identifier,
-            Keys.user: $0.uri.user,
-            Keys.host: $0.uri.host,
-            Keys.name: $0.uri.displayName,
-            Keys.date: $0.date,
-            Keys.duration: $0.duration,
-            Keys.incoming: $0.isIncoming,
-            Keys.missed: $0.isMissed
+            Keys.identifier.rawValue: $0.identifier,
+            Keys.user.rawValue: $0.uri.user,
+            Keys.host.rawValue: $0.uri.host,
+            Keys.name.rawValue: $0.uri.displayName,
+            Keys.date.rawValue: $0.date,
+            Keys.duration.rawValue: $0.duration,
+            Keys.incoming.rawValue: $0.isIncoming,
+            Keys.missed.rawValue: $0.isMissed
         ]
     }
 }
 
-private enum Keys {
-    static let identifier = "identifier"
-    static let user = "user"
-    static let host = "host"
-    static let name = "name"
-    static let date = "date"
-    static let duration = "duration"
-    static let incoming = "incoming"
-    static let missed = "missed"
+private enum Keys: String {
+    case identifier, user, host, name, date, duration, incoming, missed
 }

--- a/UseCasesTestDoubles/CallHistoryRecordRemoveUseCaseFactorySpy.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordRemoveUseCaseFactorySpy.swift
@@ -19,7 +19,7 @@
 import UseCases
 
 public final class CallHistoryRecordRemoveUseCaseFactorySpy {
-    public fileprivate(set) var invokedIndex = -1
+    public fileprivate(set) var invokedIdentifier: String?
 
     fileprivate let remove: UseCase
 
@@ -29,8 +29,8 @@ public final class CallHistoryRecordRemoveUseCaseFactorySpy {
 }
 
 extension CallHistoryRecordRemoveUseCaseFactorySpy: CallHistoryRecordRemoveUseCaseFactory {
-    public func make(index: Int) -> UseCase {
-        invokedIndex = index
+    public func make(identifier: String) -> UseCase {
+        invokedIdentifier = identifier
         return remove
     }
 }

--- a/UseCasesTestDoubles/CallHistoryRecordTestFactory.swift
+++ b/UseCasesTestDoubles/CallHistoryRecordTestFactory.swift
@@ -23,6 +23,7 @@ public final class CallHistoryRecordTestFactory {
 
     public func makeRecord(number: Int) -> CallHistoryRecord {
         return CallHistoryRecord(
+            identifier: "identifier-\(number)",
             uri: URI(user: "user-\(number)", host: "host-\(number)", displayName: "name-\(number)"),
             date: Date(),
             duration: 615,

--- a/UseCasesTestDoubles/IdentifierGeneratorStub.swift
+++ b/UseCasesTestDoubles/IdentifierGeneratorStub.swift
@@ -1,0 +1,33 @@
+//
+//  IdentifierGeneratorStub.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import UseCases
+
+public final class IdentifierGeneratorStub {
+    fileprivate let identifier: String
+
+    public init(identifier: String) {
+        self.identifier = identifier
+    }
+}
+
+extension IdentifierGeneratorStub: IdentifierGenerator {
+    public func generate() -> String {
+        return identifier
+    }
+}

--- a/UseCasesTests/CallHistoryCallEventTargetTests.swift
+++ b/UseCasesTests/CallHistoryCallEventTargetTests.swift
@@ -32,7 +32,7 @@ final class CallHistoryCallEventTargetTests: XCTestCase {
         sut.didDisconnect(call)
 
         XCTAssertTrue(factory.invokedHistory === history)
-        XCTAssertEqual(factory.invokedRecord, CallHistoryRecord(call: call))
+        XCTAssertEqual(factory.invokedRecord, CallHistoryRecord(identifier: "any-identifier", call: call))
         XCTAssertEqual(factory.invokedDomain, account.domain)
     }
 

--- a/UseCasesTests/CallHistoryCallEventTargetTests.swift
+++ b/UseCasesTests/CallHistoryCallEventTargetTests.swift
@@ -24,22 +24,30 @@ final class CallHistoryCallEventTargetTests: XCTestCase {
     func testCreatesUseCaseWithExpectedArgumentsOnDidDisconnect() {
         let account = SimpleAccount(uuid: "any-id", domain: "any-domain")
         let history: CallHistory = TruncatingCallHistory()
-        let histories = DefaultCallHistories(factory: CallHistoryFactorySpy(history: history))
+        let identifier = "foobar"
         let factory = CallHistoryRecordAddUseCaseFactorySpy(add: UseCaseSpy())
-        let sut = CallHistoryCallEventTarget(histories: histories, factory: factory)
+        let sut = CallHistoryCallEventTarget(
+            histories: DefaultCallHistories(factory: CallHistoryFactorySpy(history: history)),
+            generator: IdentifierGeneratorStub(identifier: identifier),
+            factory: factory
+        )
         let call = makeCall(account: account)
 
         sut.didDisconnect(call)
 
         XCTAssertTrue(factory.invokedHistory === history)
-        XCTAssertEqual(factory.invokedRecord, CallHistoryRecord(identifier: "any-identifier", call: call))
+        XCTAssertEqual(factory.invokedRecord, CallHistoryRecord(identifier: identifier, call: call))
         XCTAssertEqual(factory.invokedDomain, account.domain)
     }
 
     func testExecutesUseCaseOnDidDisconnect() {
         let histories = DefaultCallHistories(factory: CallHistoryFactorySpy(history: TruncatingCallHistory()))
         let add = UseCaseSpy()
-        let sut = CallHistoryCallEventTarget(histories: histories, factory: CallHistoryRecordAddUseCaseFactorySpy(add: add))
+        let sut = CallHistoryCallEventTarget(
+            histories: histories,
+            generator: IdentifierGeneratorStub(identifier: "any"),
+            factory: CallHistoryRecordAddUseCaseFactorySpy(add: add)
+        )
         let call = makeCall(account: SimpleAccount(uuid: "any-id", domain: "any-domain"))
 
         sut.didDisconnect(call)

--- a/UseCasesTests/CallHistoryRecordAddUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordAddUseCaseTests.swift
@@ -44,6 +44,7 @@ final class CallHistoryRecordAddUseCaseTests: XCTestCase {
     func testAddsCopyOfRecordWithEmptyHostWhenUserIsATelephoneNumberLongerThanFourCharacters() {
         let history = TruncatingCallHistory()
         let record = CallHistoryRecord(
+            identifier: "any-identifier",
             uri: URI(user: "12345", host: "any-host", displayName: "any-name"),
             date: Date(),
             duration: 60,
@@ -60,6 +61,7 @@ final class CallHistoryRecordAddUseCaseTests: XCTestCase {
     func testAddsOriginalRecordWhenUserIsATelephoneNumberWithLengthEqualToFourCharacters() {
         let history = TruncatingCallHistory()
         let record = CallHistoryRecord(
+            identifier: "any-identifier",
             uri: URI(user: "1234", host: "any-host", displayName: "any-name"),
             date: Date(),
             duration: 60,
@@ -76,6 +78,7 @@ final class CallHistoryRecordAddUseCaseTests: XCTestCase {
     func testAddsOriginalRecordWhenUserIsATelephoneNumberShorterThanFourCharacters() {
         let history = TruncatingCallHistory()
         let record = CallHistoryRecord(
+            identifier: "any-identifier",
             uri: URI(user: "123", host: "any-host", displayName: "any-name"),
             date: Date(),
             duration: 60,

--- a/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
@@ -29,7 +29,7 @@ final class CallHistoryRecordRemoveUseCaseTests: XCTestCase {
         history.add(record1)
         history.add(record2)
         history.add(record3)
-        let sut = CallHistoryRecordRemoveUseCase(history: history, identifier: record1.identifier)
+        let sut = CallHistoryRecordRemoveUseCase(identifier: record1.identifier, history: history)
 
         sut.execute()
 

--- a/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordRemoveUseCaseTests.swift
@@ -22,13 +22,14 @@ import XCTest
 
 final class CallHistoryRecordRemoveUseCaseTests: XCTestCase {
     func testRemovesRecord() {
+        let record1 = CallHistoryRecordTestFactory().makeRecord(number: 1)
         let record2 = CallHistoryRecordTestFactory().makeRecord(number: 2)
         let record3 = CallHistoryRecordTestFactory().makeRecord(number: 3)
         let history = TruncatingCallHistory()
-        history.add(CallHistoryRecordTestFactory().makeRecord(number: 1))
+        history.add(record1)
         history.add(record2)
         history.add(record3)
-        let sut = CallHistoryRecordRemoveUseCase(history: history, index: 0)
+        let sut = CallHistoryRecordRemoveUseCase(history: history, identifier: record1.identifier)
 
         sut.execute()
 

--- a/UseCasesTests/ContactCallHistoryRecordsGetUseCaseTests.swift
+++ b/UseCasesTests/ContactCallHistoryRecordsGetUseCaseTests.swift
@@ -71,6 +71,7 @@ final class ContactCallHistoryRecordsGetUseCaseTests: XCTestCase {
         sut.update(
             records: [
                 CallHistoryRecord(
+                    identifier: "any-identifier",
                     uri: URI(user: user, host: "", displayName: "any-name"),
                     date: Date(),
                     duration: 0,


### PR DESCRIPTION
Remove record by identifier instead of index, because records are now accessed in background.

Issue #238 