### PR TITLE
Contact matching default domain

### DIFF
--- a/Telephone/CallHistoryViewEventTargetFactory.swift
+++ b/Telephone/CallHistoryViewEventTargetFactory.swift
@@ -20,7 +20,8 @@ import UseCases
 
 final class CallHistoryViewEventTargetFactory {
     private let histories: CallHistories
-    private let matching: ContactMatching
+    private let factory: ContactMatchingIndexFactory
+    private let settings: ContactMatchingSettings
     private let dateFormatter: DateFormatter
     private let durationFormatter: DateComponentsFormatter
     private let background: ExecutionQueue
@@ -28,14 +29,16 @@ final class CallHistoryViewEventTargetFactory {
 
     init(
         histories: CallHistories,
-        matching: ContactMatching,
+        factory: ContactMatchingIndexFactory,
+        settings: ContactMatchingSettings,
         dateFormatter: DateFormatter,
         durationFormatter: DateComponentsFormatter,
         background: ExecutionQueue,
         main: ExecutionQueue
         ) {
         self.histories = histories
-        self.matching = matching
+        self.factory = factory
+        self.settings = settings
         self.dateFormatter = dateFormatter
         self.durationFormatter = durationFormatter
         self.background = background
@@ -49,7 +52,7 @@ final class CallHistoryViewEventTargetFactory {
                 origin: CallHistoryRecordsGetUseCase(
                     history: history,
                     output: ContactCallHistoryRecordsGetUseCase(
-                        matching: matching,
+                        matching: IndexedContactMatching(factory: factory, settings: settings, domain: account.domain),
                         output: EnqueuingContactCallHistoryRecordsGetUseCaseOutput(
                             origin: CallHistoryViewPresenter(
                                 view: view, dateFormatter: dateFormatter, durationFormatter: durationFormatter

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -193,10 +193,8 @@ final class CompositionRoot: NSObject {
         callHistoryViewEventTargetFactory = AsyncCallHistoryViewEventTargetFactory(
             origin: CallHistoryViewEventTargetFactory(
                 histories: callHistories,
-                matching: IndexedContactMatching(
-                    factory: DefaultContactMatchingIndexFactory(contacts: contacts),
-                    settings: SimpleContactMatchingSettings(settings: defaults)
-                ),
+                factory: DefaultContactMatchingIndexFactory(contacts: contacts),
+                settings: SimpleContactMatchingSettings(settings: defaults),
                 dateFormatter: ShortRelativeDateTimeFormatter(),
                 durationFormatter: DurationFormatter(),
                 background: contactsBackground,

--- a/UseCases/IndexedContactMatching.swift
+++ b/UseCases/IndexedContactMatching.swift
@@ -22,10 +22,12 @@ public final class IndexedContactMatching {
 
     private let factory: ContactMatchingIndexFactory
     private let settings: ContactMatchingSettings
+    fileprivate let domain: String
 
-    public init(factory: ContactMatchingIndexFactory, settings: ContactMatchingSettings) {
+    public init(factory: ContactMatchingIndexFactory, settings: ContactMatchingSettings, domain: String) {
         self.factory = factory
         self.settings = settings
+        self.domain = domain
     }
 }
 
@@ -35,10 +37,14 @@ extension IndexedContactMatching: ContactMatching {
     }
 
     private func emailMatch(for uri: URI) -> MatchedContact? {
-        return index.contact(forEmail: NormalizedLowercasedString("\(uri.user)@\(uri.host)"))
+        return index.contact(forEmail: NormalizedLowercasedString(email(for: uri)))
     }
 
     private func phoneNumberMatch(for uri: URI) -> MatchedContact? {
         return index.contact(forPhone: ExtractedPhoneNumber(uri.user, maxLength: length))
+    }
+
+    private func email(for uri: URI) -> String {
+        return uri.host.isEmpty ? "\(uri.user)@\(domain)" : "\(uri.user)@\(uri.host)"
     }
 }


### PR DESCRIPTION
Use account domain when trying to find contact for a URI with an empty host part.

Issue #238 