### PR TITLE
Get call history record by identifier instead of index

### DIFF
--- a/Telephone/CallHistoryViewController.swift
+++ b/Telephone/CallHistoryViewController.swift
@@ -63,7 +63,7 @@ final class CallHistoryViewController: NSViewController {
 
     private func pickRecord() {
         guard !records.isEmpty else { return }
-        target?.didPickRecord(at: tableView.selectedRow)
+        target?.didPickRecord(withIdentifier: records[tableView.selectedRow].identifier)
     }
 
     private func deleteRecord() {

--- a/Telephone/CallHistoryViewEventTarget.swift
+++ b/Telephone/CallHistoryViewEventTarget.swift
@@ -33,8 +33,8 @@ final class CallHistoryViewEventTarget: NSObject {
         recordsGet.execute()
     }
 
-    func didPickRecord(at index: Int) {
-        callMake.make(index: index).execute()
+    func didPickRecord(withIdentifier identifier: String) {
+        callMake.make(identifier: identifier).execute()
     }
 
     func shouldRemoveRecord(withIdentifier identifier: String) {

--- a/Telephone/EnqueuingCallHistoryCallMakeUseCaseFactory.swift
+++ b/Telephone/EnqueuingCallHistoryCallMakeUseCaseFactory.swift
@@ -33,11 +33,11 @@ final class EnqueuingCallHistoryCallMakeUseCaseFactory {
 }
 
 extension EnqueuingCallHistoryCallMakeUseCaseFactory: CallHistoryCallMakeUseCaseFactory {
-    func make(index: Int) -> UseCase {
+    func make(identifier: String) -> UseCase {
         return EnqueuingUseCase(
             origin: CallHistoryRecordGetUseCase(
+                identifier: identifier,
                 history: history,
-                index: index,
                 output: EnqueuingCallHistoryRecordGetUseCaseOutput(
                     origin: CallHistoryCallMakeUseCase(account: account), queue: accountQueue
                 )

--- a/TelephoneTests/CallHistoryViewEventTargetTests.swift
+++ b/TelephoneTests/CallHistoryViewEventTargetTests.swift
@@ -46,17 +46,18 @@ final class CallHistoryViewEventTargetTests: XCTestCase {
         XCTAssertTrue(get.didCallExecute)
     }
 
-    func testCreatesCallHistoryCallMakeUseCaseWithExpectedIndexOnDidPickRecord() {
+    func testCreatesCallHistoryCallMakeUseCaseWithExpectedIdentifierOnDidPickRecord() {
         let factory = CallHistoryCallMakeUseCaseFactorySpy(callMake: UseCaseSpy())
         let sut = CallHistoryViewEventTarget(
             recordsGet: UseCaseSpy(),
             recordRemove: CallHistoryRecordRemoveUseCaseFactorySpy(remove: UseCaseSpy()),
             callMake: factory
         )
+        let identifier = "any"
 
-        sut.didPickRecord(at: 3)
+        sut.didPickRecord(withIdentifier: identifier)
 
-        XCTAssertEqual(factory.invokedIndex, 3)
+        XCTAssertEqual(factory.invokedIdentifier, identifier)
     }
 
     func testExecutesCallHistoryCallMakeUseCaseOnDidPickRecord() {
@@ -67,12 +68,12 @@ final class CallHistoryViewEventTargetTests: XCTestCase {
             callMake: CallHistoryCallMakeUseCaseFactorySpy(callMake: callMake)
         )
 
-        sut.didPickRecord(at: 1)
+        sut.didPickRecord(withIdentifier: "any")
 
         XCTAssertTrue(callMake.didCallExecute)
     }
 
-    func testCreatesCallHistoryRecordRemoveUseCaseWithExpectedIndexOnShouldRemoveRecord() {
+    func testCreatesCallHistoryRecordRemoveUseCaseWithExpectedIdentifierOnShouldRemoveRecord() {
         let factory = CallHistoryRecordRemoveUseCaseFactorySpy(remove: UseCaseSpy())
         let sut = CallHistoryViewEventTarget(
             recordsGet: UseCaseSpy(),

--- a/UseCases/CallHistoryCallMakeUseCaseFactory.swift
+++ b/UseCases/CallHistoryCallMakeUseCaseFactory.swift
@@ -14,5 +14,5 @@
 //
 
 public protocol CallHistoryCallMakeUseCaseFactory {
-    func make(index: Int) -> UseCase
+    func make(identifier: String) -> UseCase
 }

--- a/UseCases/CallHistoryRecordGetUseCase.swift
+++ b/UseCases/CallHistoryRecordGetUseCase.swift
@@ -17,19 +17,21 @@
 //
 
 public final class CallHistoryRecordGetUseCase {
+    fileprivate let identifier: String
     fileprivate let history: CallHistory
-    fileprivate let index: Int
     fileprivate let output: CallHistoryRecordGetUseCaseOutput
 
-    public init(history: CallHistory, index: Int, output: CallHistoryRecordGetUseCaseOutput) {
+    public init(identifier: String, history: CallHistory, output: CallHistoryRecordGetUseCaseOutput) {
+        self.identifier = identifier
         self.history = history
-        self.index = index
         self.output = output
     }
 }
 
 extension CallHistoryRecordGetUseCase: UseCase {
     public func execute() {
-        output.update(record: history.allRecords[index])
+        if let record = history.record(withIdentifier: identifier) {
+            output.update(record: record)
+        }
     }
 }

--- a/UseCasesTestDoubles/CallHistoryCallMakeUseCaseFactorySpy.swift
+++ b/UseCasesTestDoubles/CallHistoryCallMakeUseCaseFactorySpy.swift
@@ -19,7 +19,7 @@
 import UseCases
 
 public final class CallHistoryCallMakeUseCaseFactorySpy {
-    public fileprivate(set) var invokedIndex = -1
+    public fileprivate(set) var invokedIdentifier: String?
     fileprivate let callMake: UseCase
 
     public init(callMake: UseCase) {
@@ -28,8 +28,8 @@ public final class CallHistoryCallMakeUseCaseFactorySpy {
 }
 
 extension CallHistoryCallMakeUseCaseFactorySpy: CallHistoryCallMakeUseCaseFactory {
-    public func make(index: Int) -> UseCase {
-        invokedIndex = index
+    public func make(identifier: String) -> UseCase {
+        invokedIdentifier = identifier
         return callMake
     }
 }

--- a/UseCasesTests/CallHistoryRecordGetUseCaseTests.swift
+++ b/UseCasesTests/CallHistoryRecordGetUseCaseTests.swift
@@ -21,20 +21,29 @@ import UseCases
 import UseCasesTestDoubles
 
 final class CallHistoryRecordGetUseCaseTests: XCTestCase {
-    func testCallsUpdateWithRecordAtIndexFromHistoryOnExecute() {
+    func testCallsUpdateWithRecordWithIdentifierFromHistoryOnExecute() {
         let factory = CallHistoryRecordTestFactory()
         let history = TruncatingCallHistory()
         history.add(factory.makeRecord(number: 1))
         history.add(factory.makeRecord(number: 2))
         history.add(factory.makeRecord(number: 3))
         history.add(factory.makeRecord(number: 4))
-        let index = 2
+        let result = history.allRecords[2]
         let output = CallHistoryRecordGetUseCaseOutputSpy()
-        let sut = CallHistoryRecordGetUseCase(history: history, index: index, output: output)
+        let sut = CallHistoryRecordGetUseCase(identifier: result.identifier, history: history, output: output)
 
         sut.execute()
 
         XCTAssertTrue(output.didCallUpdate)
-        XCTAssertEqual(output.invokedRecord, history.allRecords[index])
+        XCTAssertEqual(output.invokedRecord, result)
+    }
+
+    func testDoesNotCallUpdateWhenRecordWithGivenIdentifierIsNotFoundOnExecute() {
+        let output = CallHistoryRecordGetUseCaseOutputSpy()
+        let sut = CallHistoryRecordGetUseCase(identifier: "nonexistent", history: TruncatingCallHistory(), output: output)
+
+        sut.execute()
+
+        XCTAssertFalse(output.didCallUpdate)
     }
 }


### PR DESCRIPTION
This is needed to avoid making a call using an incorrect record when the list of records in the UI that works on the main thread is different from the list of records in the call history that is being access in background.

Issue #238 