### PR TITLE
Sanitize call destination

### DIFF
--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -320,6 +320,9 @@
 		8AA749031D749E4D000587DC /* StoreViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8AA749051D749E4D000587DC /* StoreViewController.xib */; };
 		8AA749321D75FF18000587DC /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA749311D75FF18000587DC /* StoreKit.framework */; };
 		8AA791FC1CE245940082E4FC /* AsyncProductsFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA791FB1CE245940082E4FC /* AsyncProductsFake.swift */; };
+		8AA891DC1F83F69F0064B2EA /* SanitizedCallDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA891DB1F83F69F0064B2EA /* SanitizedCallDestinationTests.swift */; };
+		8AA891DE1F83F6EA0064B2EA /* SanitizedCallDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA891DD1F83F6EA0064B2EA /* SanitizedCallDestination.swift */; };
+		8AA891DF1F83F7100064B2EA /* SanitizedCallDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA891DD1F83F6EA0064B2EA /* SanitizedCallDestination.swift */; };
 		8AAA5BE51DA695D2005A7BFE /* ReceiptRefreshUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAA5BE41DA695D2005A7BFE /* ReceiptRefreshUseCase.swift */; };
 		8AAACA011CAE9EE5001930C4 /* SoundIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAACA001CAE9EE5001930C4 /* SoundIO.swift */; };
 		8AAACA031CAE9F36001930C4 /* SimpleSoundIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAACA021CAE9F36001930C4 /* SimpleSoundIO.swift */; };
@@ -1133,6 +1136,8 @@
 		8AA749301D75E5E7000587DC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		8AA749311D75FF18000587DC /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		8AA791FB1CE245940082E4FC /* AsyncProductsFake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncProductsFake.swift; sourceTree = "<group>"; };
+		8AA891DB1F83F69F0064B2EA /* SanitizedCallDestinationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SanitizedCallDestinationTests.swift; path = TelephoneTests/SanitizedCallDestinationTests.swift; sourceTree = SOURCE_ROOT; };
+		8AA891DD1F83F6EA0064B2EA /* SanitizedCallDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SanitizedCallDestination.swift; sourceTree = "<group>"; };
 		8AAA5BE41DA695D2005A7BFE /* ReceiptRefreshUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptRefreshUseCase.swift; sourceTree = "<group>"; };
 		8AAACA001CAE9EE5001930C4 /* SoundIO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoundIO.swift; sourceTree = "<group>"; };
 		8AAACA021CAE9F36001930C4 /* SimpleSoundIO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleSoundIO.swift; sourceTree = "<group>"; };
@@ -1653,6 +1658,8 @@
 				8ADD6A691CE0C8CF001EDBBA /* PresenterFactory.swift */,
 				8AD2C5F01EAE0C94005EED3E /* RestoredSelectionIndex.swift */,
 				8AD2C5EE1EAE0C58005EED3E /* RestoredSelectionIndexTests.swift */,
+				8AA891DD1F83F6EA0064B2EA /* SanitizedCallDestination.swift */,
+				8AA891DB1F83F69F0064B2EA /* SanitizedCallDestinationTests.swift */,
 				8AA748821D6DEE61000587DC /* SettingsAccount.swift */,
 				8AA748801D6DECAB000587DC /* SettingsAccounts.swift */,
 				8AA748841D6F0D00000587DC /* SettingsAccountsTests.swift */,
@@ -3571,6 +3578,7 @@
 				AABAD7ED0E0C171A00CB5930 /* PreferencesController.m in Sources */,
 				8A42E0C81E168F4F00CE09B8 /* DurationFormatter.swift in Sources */,
 				AA2CCC840E2E4EEB00871057 /* AKSIPCall.m in Sources */,
+				8AA891DE1F83F6EA0064B2EA /* SanitizedCallDestination.swift in Sources */,
 				8AF52BE11F028A50001F7784 /* ABAddressBookNotificationsToContactsChangeEventTargetAdapter.swift in Sources */,
 				8AB5A0CB1D084E4F00579CE8 /* PresentationProduct.swift in Sources */,
 				8A91759F1CA59F1100354E26 /* PJSUAOnCallMediaState.m in Sources */,
@@ -3954,12 +3962,14 @@
 				8ADD6A5D1CDCFEC3001EDBBA /* DefaultStoreViewEventTargetTests.swift in Sources */,
 				8A1DA8161DF07EF300F5BA40 /* WorkspaceSleepStatus.swift in Sources */,
 				8A57AEA71CBEAF1200A36200 /* AKSIPCallNotifications.m in Sources */,
+				8AA891DC1F83F69F0064B2EA /* SanitizedCallDestinationTests.swift in Sources */,
 				8ADA10A71DC8D6E90038E0A5 /* SettingsMigrationFactory.swift in Sources */,
 				8ABB141C1CEC86B10056CEDC /* StoreViewStateMachine.swift in Sources */,
 				8ADA109D1DC8D3040038E0A5 /* ProgressiveSettingsMigrationTests.swift in Sources */,
 				8AD2C5F21EAE0C94005EED3E /* RestoredSelectionIndex.swift in Sources */,
 				8AA27AF21E9D3982002A08CD /* SimplePropertyListStorageURLTests.swift in Sources */,
 				AA1019881C490BF100869D01 /* RepeatingSoundFactory.swift in Sources */,
+				8AA891DF1F83F7100064B2EA /* SanitizedCallDestination.swift in Sources */,
 				8A41A74D1E5B4F3400E0C854 /* CallHistoryViewEventTargetTests.swift in Sources */,
 				8AA27AF11E9D397B002A08CD /* SimplePropertyListStorageURL.swift in Sources */,
 				8AA748BE1D704A40000587DC /* MusicPlayersTests.swift in Sources */,

--- a/Telephone/AccountController.h
+++ b/Telephone/AccountController.h
@@ -27,7 +27,7 @@ extern NSString * const kEmailSIPLabel;
 
 @class AKSIPURI, AKNetworkReachability;
 @class AsyncCallHistoryPurchaseCheckUseCaseFactory, AsyncCallHistoryViewEventTargetFactory;
-@class CallTransferController, StoreWindowPresenter, WorkspaceSleepStatus;
+@class CallTransferController, SanitizedCallDestination, StoreWindowPresenter, WorkspaceSleepStatus;
 @protocol MusicPlayer, RingtonePlaybackUseCase;
 
 @interface AccountController : NSObject <AKSIPAccountDelegate, CallControllerDelegate>
@@ -76,7 +76,7 @@ extern NSString * const kEmailSIPLabel;
 
 - (void)makeCallToURI:(AKSIPURI *)destinationURI phoneLabel:(NSString *)phoneLabel;
 
-- (void)makeCallToDestinationRegisteringAccountIfNeeded:(NSString *)destination;
+- (void)makeCallToDestinationRegisteringAccountIfNeeded:(SanitizedCallDestination *)destination;
 
 - (void)showWindow;
 - (void)showWindowWithoutMakingKey;

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -387,12 +387,12 @@ static NSString * const kRussian = @"ru";
     }
 }
 
-- (void)makeCallToDestinationRegisteringAccountIfNeeded:(NSString *)destination {
+- (void)makeCallToDestinationRegisteringAccountIfNeeded:(SanitizedCallDestination *)destination {
     if (![self isAccountAdded]) {
-        [self setDestinationToCall:destination];
+        [self setDestinationToCall:destination.value];
         [self registerAccount];
     } else {
-        [self makeCallToDestination:destination];
+        [self makeCallToDestination:destination.value];
     }
 }
 

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -1432,7 +1432,8 @@ NS_ASSUME_NONNULL_END
 
 - (void)makeCallTo:(NSString *)destination {
     if ([self canMakeCall]) {
-        [self.enabledAccountControllers[0] makeCallToDestinationRegisteringAccountIfNeeded:destination];
+        [self.enabledAccountControllers[0] makeCallToDestinationRegisteringAccountIfNeeded:
+         [[SanitizedCallDestination alloc] initWithString:destination].value];
     }
 }
 

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -1433,7 +1433,7 @@ NS_ASSUME_NONNULL_END
 - (void)makeCallTo:(NSString *)destination {
     if ([self canMakeCall]) {
         [self.enabledAccountControllers[0] makeCallToDestinationRegisteringAccountIfNeeded:
-         [[SanitizedCallDestination alloc] initWithString:destination].value];
+         [[SanitizedCallDestination alloc] initWithString:destination]];
     }
 }
 

--- a/Telephone/SanitizedCallDestination.swift
+++ b/Telephone/SanitizedCallDestination.swift
@@ -1,0 +1,45 @@
+//
+//  SanitizedCallDestination.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import Foundation
+
+final class SanitizedCallDestination: NSObject {
+    let value: String
+
+    init(_ string: String) {
+        value = strippingSlashes(from: strippingHeaders(from: string))
+    }
+}
+
+private func strippingSlashes(from string: String) -> String {
+    if let range = string.range(of: "sip://") {
+        return string.replacingCharacters(in: range, with: "sip:")
+    } else if let range = string.range(of: "tel://") {
+        return string.replacingCharacters(in: range, with: "tel:")
+    } else {
+        return string
+    }
+}
+
+private func strippingHeaders(from string: String) -> String {
+    if let range = string.range(of: "?") {
+        return String(string[..<range.lowerBound])
+    } else {
+        return string
+    }
+}

--- a/Telephone/SanitizedCallDestination.swift
+++ b/Telephone/SanitizedCallDestination.swift
@@ -19,8 +19,9 @@
 import Foundation
 
 final class SanitizedCallDestination: NSObject {
-    let value: String
+    @objc let value: String
 
+    @objc(initWithString:)
     init(_ string: String) {
         value = strippingSlashes(from: strippingHeaders(from: string))
     }

--- a/TelephoneTests/SanitizedCallDestinationTests.swift
+++ b/TelephoneTests/SanitizedCallDestinationTests.swift
@@ -1,0 +1,45 @@
+//
+//  SanitizedCallDestinationTests.swift
+//  TelephoneTests
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2017 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import XCTest
+
+final class SanitizedCallDestinationTests: XCTestCase {
+    func testReturnsOriginalString() {
+        XCTAssertEqual(SanitizedCallDestination("any").value, "any")
+    }
+
+    func testRemovesSlashesWhenBeginsWithSIP() {
+        XCTAssertEqual(SanitizedCallDestination("sip://user@host").value, "sip:user@host")
+    }
+
+    func testRemovesSlashesWhenBeginsWithTel() {
+        XCTAssertEqual(SanitizedCallDestination("tel://12345").value, "tel:12345")
+    }
+
+    func testRemovesHeaders() {
+        XCTAssertEqual(SanitizedCallDestination("any?headers").value, "any")
+    }
+
+    func testRemovesHeadersFromSIPURI() {
+        XCTAssertEqual(SanitizedCallDestination("sip:any?headers").value, "sip:any")
+    }
+
+    func testRemovesHeadersFromTelURI() {
+        XCTAssertEqual(SanitizedCallDestination("tel:123?headers").value, "tel:123")
+    }
+}


### PR DESCRIPTION
Sanitize call destination when calling from external sources by removing slashes from URI schemes and headers from URIs.

Closes #324 