### PR TITLE
Call window auto close

### DIFF
--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -183,8 +183,8 @@ NS_ASSUME_NONNULL_END
         defaultsDict[kTransportPublicHost] = @"";
         defaultsDict[kRingingSound] = @"Purr";
         defaultsDict[kSignificantPhoneNumberLength] = @9;
-        defaultsDict[kAutoCloseCallWindow] = @NO;
-        defaultsDict[kAutoCloseMissedCallWindow] = @NO;
+        defaultsDict[kAutoCloseCallWindow] = @YES;
+        defaultsDict[kAutoCloseMissedCallWindow] = @YES;
         defaultsDict[kCallWaiting] = @YES;
         defaultsDict[kUseG711Only] = @NO;
 

--- a/Telephone/CallController.m
+++ b/Telephone/CallController.m
@@ -567,9 +567,7 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
     BOOL missed = [self isCallUnhandled];
     
     if (![self isKindOfClass:[CallTransferController class]]) {
-        if ((!missed && shouldCloseWindow) ||
-            (missed && shouldCloseWindow && shouldCloseMissedWindow)) {
-            
+        if ((!missed && shouldCloseWindow) || (missed && shouldCloseMissedWindow)) {
             [self performSelector:@selector(closeCallWindow) withObject:nil afterDelay:kCallWindowAutoCloseTime];
         }
     }


### PR DESCRIPTION
* Automatically close call windows by default. Both, missed and not missed.
* Control auto closing of missed call windows independently from the normal window auto close setting.