### PR TITLE
Get call info within callback before dispatching to main

### DIFF
--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -124,7 +124,7 @@ extern const NSInteger kAKSIPAccountDefaultReregistrationTime;
 // Makes a call to a given destination URI.
 - (void)makeCallTo:(AKSIPURI *)destination completion:(void (^)(AKSIPCall *))completion;
 
-- (AKSIPCall *)addCallWithIdentifier:(NSInteger)identifier;
+- (AKSIPCall *)addCallWithInfo:(pjsua_call_info)info;
 - (nullable AKSIPCall *)callWithIdentifier:(NSInteger)identifier;
 - (void)removeCall:(AKSIPCall *)call;
 - (void)removeAllCalls;

--- a/Telephone/AKSIPAccount.m
+++ b/Telephone/AKSIPAccount.m
@@ -33,11 +33,11 @@ const NSInteger kAKSIPAccountDefaultReregistrationTime = 300;
 
 @property(nonatomic, readonly) AKSIPURI *destination;
 @property(nonatomic, readonly) pjsua_acc_id account;
-@property(nonatomic, readonly) void (^ _Nonnull completion)(BOOL, pjsua_call_id);
+@property(nonatomic, readonly) void (^ _Nonnull completion)(BOOL, pjsua_call_info);
 
 - (instancetype)initWithDestination:(AKSIPURI *)destination
                             account:(pjsua_acc_id)account
-                         completion:(void (^ _Nonnull)(BOOL, pjsua_call_id))completion;
+                         completion:(void (^ _Nonnull)(BOOL, pjsua_call_info))completion;
 
 @end
 
@@ -264,9 +264,9 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)makeCallTo:(AKSIPURI *)destination completion:(void (^ _Nonnull)(AKSIPCall * _Nullable))completion {
-    void (^onCallMakeCompletion)(BOOL, pjsua_call_id) = ^(BOOL success, pjsua_call_id callID) {
+    void (^onCallMakeCompletion)(BOOL, pjsua_call_info) = ^(BOOL success, pjsua_call_info call) {
         if (success) {
-            completion([self addCallWithIdentifier:callID]);
+            completion([self addCallWithInfo:call]);
         } else {
             NSLog(@"Error making call to %@ via account %@", destination, self);
             completion(nil);
@@ -283,13 +283,15 @@ NS_ASSUME_NONNULL_END
     pj_str_t uri = parameters.destination.description.pjString;
     pjsua_call_id callID = PJSUA_INVALID_ID;
     BOOL success = pjsua_call_make_call(parameters.account, &uri, 0, NULL, NULL, &callID) == PJ_SUCCESS;
-    dispatch_async(dispatch_get_main_queue(), ^{ parameters.completion(success, callID); });
+    pjsua_call_info call;
+    pjsua_call_get_info(callID, &call);
+    dispatch_async(dispatch_get_main_queue(), ^{ parameters.completion(success, call); });
 }
 
-- (AKSIPCall *)addCallWithIdentifier:(NSInteger)identifier {
-    AKSIPCall *call = [self callWithIdentifier:identifier];
+- (AKSIPCall *)addCallWithInfo:(pjsua_call_info)info {
+    AKSIPCall *call = [self callWithIdentifier:info.id];
     if (!call) {
-        call = [[AKSIPCall alloc] initWithSIPAccount:self identifier:identifier];
+        call = [[AKSIPCall alloc] initWithSIPAccount:self info:info];
         [self.calls addObject:call];
     }
     return call;
@@ -318,7 +320,7 @@ NS_ASSUME_NONNULL_END
 
 - (instancetype)initWithDestination:(AKSIPURI *)destination
                             account:(pjsua_acc_id)account
-                         completion:(void (^ _Nonnull)(BOOL, pjsua_call_id))completion {
+                         completion:(void (^ _Nonnull)(BOOL, pjsua_call_info))completion {
     if ((self = [super init])) {
         _destination = destination;
         _account = account;

--- a/Telephone/AKSIPCall.h
+++ b/Telephone/AKSIPCall.h
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSUInteger, AKSIPCallState) {
 @property(nonatomic, readonly, getter=isOnLocalHold) BOOL onLocalHold;
 @property(nonatomic, readonly, getter=isOnRemoteHold) BOOL onRemoteHold;
 
-- (instancetype)initWithSIPAccount:(AKSIPAccount *)account identifier:(NSInteger)identifier;
+- (instancetype)initWithSIPAccount:(AKSIPAccount *)account info:(pjsua_call_info)info;
 
 - (void)answer;
 - (void)hangUp;

--- a/Telephone/AKSIPCall.m
+++ b/Telephone/AKSIPCall.m
@@ -169,28 +169,25 @@ const NSInteger kAKSIPCallsMax = 8;
 
 #pragma mark -
 
-- (instancetype)initWithSIPAccount:(AKSIPAccount *)account identifier:(NSInteger)identifier {
+- (instancetype)initWithSIPAccount:(AKSIPAccount *)account info:(pjsua_call_info)info {
     self = [super init];
     if (self == nil) {
         return nil;
     }
 
     _account = account;
-    _identifier = identifier;
+    _identifier = info.id;
 
     _date = [NSDate date];
 
-    pjsua_call_info call;
-    pj_status_t status = pjsua_call_get_info((pjsua_call_id)identifier, &call);
-    assert(status == PJ_SUCCESS);
-    _incoming = call.role == PJSIP_ROLE_UAS;
+    _incoming = info.role == PJSIP_ROLE_UAS;
     _missed = _incoming;
-    _state = (AKSIPCallState)call.state;
-    _stateText = [NSString stringWithPJString:call.state_text];
-    _lastStatus = call.last_status;
-    _lastStatusText = [NSString stringWithPJString:call.last_status_text];
-    _localURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:call.local_info]];
-    _remoteURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:call.remote_info]];
+    _state = (AKSIPCallState)info.state;
+    _stateText = [NSString stringWithPJString:info.state_text];
+    _lastStatus = info.last_status;
+    _lastStatusText = [NSString stringWithPJString:info.last_status_text];
+    _localURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:info.local_info]];
+    _remoteURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:info.remote_info]];
     _remote = [[URI alloc] initWithURI:_remoteURI];
 
     return self;

--- a/Telephone/PJSUAOnCallReplaced.m
+++ b/Telephone/PJSUAOnCallReplaced.m
@@ -24,22 +24,20 @@
 
 #define THIS_FILE "PJSUAOnCallReplaced.m"
 
-void PJSUAOnCallReplaced(pjsua_call_id oldCallID, pjsua_call_id newCallID) {
-    pjsua_call_info oldCallInfo, newCallInfo;
-    pjsua_call_get_info(oldCallID, &oldCallInfo);
-    pjsua_call_get_info(newCallID, &newCallInfo);
+void PJSUAOnCallReplaced(pjsua_call_id oldID, pjsua_call_id newID) {
+    pjsua_call_info oldInfo, newInfo;
+    pjsua_call_get_info(oldID, &oldInfo);
+    pjsua_call_get_info(newID, &newInfo);
 
     PJ_LOG(3, (THIS_FILE, "Call %d with %.*s is being replaced by call %d with %.*s",
-               oldCallID,
-               (int)oldCallInfo.remote_info.slen, oldCallInfo.remote_info.ptr,
-               newCallID,
-               (int)newCallInfo.remote_info.slen, newCallInfo.remote_info.ptr));
+               oldID, (int)oldInfo.remote_info.slen, oldInfo.remote_info.ptr,
+               newID, (int)newInfo.remote_info.slen, newInfo.remote_info.ptr));
 
-    NSInteger accountIdentifier = newCallInfo.acc_id;
+    NSInteger accountIdentifier = newInfo.acc_id;
     dispatch_async(dispatch_get_main_queue(), ^{
-        PJ_LOG(3, (THIS_FILE, "Creating AKSIPCall for call %d from replaced callback", newCallID));
+        PJ_LOG(3, (THIS_FILE, "Creating AKSIPCall for call %d from replaced callback", newID));
         AKSIPUserAgent *userAgent = [AKSIPUserAgent sharedUserAgent];
         AKSIPAccount *account = [userAgent accountWithIdentifier:accountIdentifier];
-        [account addCallWithIdentifier:newCallID];
+        [account addCallWithInfo:newInfo];
     });
 }

--- a/Telephone/PJSUAOnIncomingCall.m
+++ b/Telephone/PJSUAOnIncomingCall.m
@@ -26,9 +26,11 @@
 
 void PJSUAOnIncomingCall(pjsua_acc_id accountID, pjsua_call_id callID, pjsip_rx_data *invite) {
     PJ_LOG(3, (THIS_FILE, "Incoming call for account %d", accountID));
+    pjsua_call_info info;
+    pjsua_call_get_info(callID, &info);
     dispatch_async(dispatch_get_main_queue(), ^{
         AKSIPAccount *account = [[AKSIPUserAgent sharedUserAgent] accountWithIdentifier:accountID];
-        AKSIPCall *call = [account addCallWithIdentifier:callID];
+        AKSIPCall *call = [account addCallWithInfo:info];
         [account.delegate SIPAccount:account didReceiveCall:call];
         [[NSNotificationCenter defaultCenter] postNotificationName:AKSIPCallIncomingNotification object:call];
     });


### PR DESCRIPTION
A race condition occurred when only the call id was passed to main thread. Sometimes, the call to `pjsua_call_get_info()` was made too late, when the PJSIP call didn't exist any more. Now, the call info is got within the callback in backgroun and the whole call info structure is passed to the main thread.

Closes #433