### PR TITLE
PCMA before PCMU

### DIFF
--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -718,8 +718,8 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
                        @"opus/48000/2":  @(127),
                        @"iLBC/8000/1":   @(126),
                        @"GSM/8000/1":    @(125),
-                       @"PCMU/8000/1":   @(124),
-                       @"PCMA/8000/1":   @(123),
+                       @"PCMA/8000/1":   @(124),
+                       @"PCMU/8000/1":   @(123),
                        @"G722/16000/1":  @(122)
                        };
     });


### PR DESCRIPTION
This is believed to be better compatible with Deutsche Telekom. For some destinations, it works only when PCMA is the preferred codec.

Closes #442