### PR TITLE
Check active calls count before resuming music player

### DIFF
--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -175,6 +175,8 @@
 		8A4D0B001C96D6F8005543A2 /* RingtoneOutputUpdateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4D0AFF1C96D6F8005543A2 /* RingtoneOutputUpdateUseCase.swift */; };
 		8A4E38301C5BB20100816F38 /* SettingsRingtoneSoundNameSaveUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E382F1C5BB20100816F38 /* SettingsRingtoneSoundNameSaveUseCaseTests.swift */; };
 		8A4E38321C5BB25F00816F38 /* SettingsRingtoneSoundNameSaveUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E38311C5BB25F00816F38 /* SettingsRingtoneSoundNameSaveUseCase.swift */; };
+		8A506B3B204B380800EE3F25 /* CallEventTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506B3A204B380800EE3F25 /* CallEventTargetsTests.swift */; };
+		8A506B3D204B387A00EE3F25 /* CallEventTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A506B3C204B387A00EE3F25 /* CallEventTargets.swift */; };
 		8A57AEA61CBEAF1200A36200 /* AKSIPCallNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A57AEA51CBEAF1200A36200 /* AKSIPCallNotifications.m */; };
 		8A57AEA71CBEAF1200A36200 /* AKSIPCallNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A57AEA51CBEAF1200A36200 /* AKSIPCallNotifications.m */; };
 		8A5D17511EBCD32700A95FB8 /* ExtractedPhoneNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5D17501EBCD32700A95FB8 /* ExtractedPhoneNumberTests.swift */; };
@@ -999,6 +1001,8 @@
 		8A4D0AFF1C96D6F8005543A2 /* RingtoneOutputUpdateUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RingtoneOutputUpdateUseCase.swift; sourceTree = "<group>"; };
 		8A4E382F1C5BB20100816F38 /* SettingsRingtoneSoundNameSaveUseCaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SettingsRingtoneSoundNameSaveUseCaseTests.swift; path = UseCasesTests/SettingsRingtoneSoundNameSaveUseCaseTests.swift; sourceTree = SOURCE_ROOT; };
 		8A4E38311C5BB25F00816F38 /* SettingsRingtoneSoundNameSaveUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsRingtoneSoundNameSaveUseCase.swift; sourceTree = "<group>"; };
+		8A506B3A204B380800EE3F25 /* CallEventTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CallEventTargetsTests.swift; path = UseCasesTests/CallEventTargetsTests.swift; sourceTree = SOURCE_ROOT; };
+		8A506B3C204B387A00EE3F25 /* CallEventTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallEventTargets.swift; sourceTree = "<group>"; };
 		8A57AEA41CBEAF1200A36200 /* AKSIPCallNotifications.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AKSIPCallNotifications.h; sourceTree = "<group>"; };
 		8A57AEA51CBEAF1200A36200 /* AKSIPCallNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AKSIPCallNotifications.m; sourceTree = "<group>"; };
 		8A5D17501EBCD32700A95FB8 /* ExtractedPhoneNumberTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExtractedPhoneNumberTests.swift; path = UseCasesTests/ExtractedPhoneNumberTests.swift; sourceTree = SOURCE_ROOT; };
@@ -1897,6 +1901,8 @@
 			isa = PBXGroup;
 			children = (
 				8A11B3CD1DDB46B8002EDA93 /* CallEventTarget.swift */,
+				8A506B3C204B387A00EE3F25 /* CallEventTargets.swift */,
+				8A506B3A204B380800EE3F25 /* CallEventTargetsTests.swift */,
 				8A11B3D11DDB6D9A002EDA93 /* CallHistoryCallEventTarget.swift */,
 				8A11B3CF1DDB6D41002EDA93 /* CallHistoryCallEventTargetTests.swift */,
 				8AAFE61C1EE1A2BA00BACC62 /* EnqueuingCallEventTarget.swift */,
@@ -3859,6 +3865,7 @@
 				8A61363B1CC23AA000A087A4 /* SystemAudioDevicesChangeEventTarget.swift in Sources */,
 				8A9513E41D2A6CCA0034DF2C /* ReceiptValidatingStoreEventTarget.swift in Sources */,
 				8A9513D71D22CD8A0034DF2C /* StoreEventTarget.swift in Sources */,
+				8A506B3D204B387A00EE3F25 /* CallEventTargets.swift in Sources */,
 				8A4B65B91EB21D6900F13654 /* SimpleContactMatchingIndex.swift in Sources */,
 				8ADEDBF71ECF49FA00987B77 /* SimpleContactMatchingSettings.swift in Sources */,
 				AA39052C1BFFDDC4005A8AA3 /* UseCase.swift in Sources */,
@@ -3961,6 +3968,7 @@
 				8AB677F11F0AABBA001A47A2 /* MatchedContactTests.swift in Sources */,
 				8ADD31CC1CC165B5008C083C /* DelayingUserAgentSoundIOSelectionUseCaseTests.swift in Sources */,
 				8AA748B61D704657000587DC /* SimpleMusicPlayerSettingsTests.swift in Sources */,
+				8A506B3B204B380800EE3F25 /* CallEventTargetsTests.swift in Sources */,
 				8A32A4EA1D675A300086B49D /* PurchaseCheckUseCaseTests.swift in Sources */,
 				8A2BAAE01F06C1E700A1801E /* FallingBackMatchedContactFactoryTests.swift in Sources */,
 				8AE396EC1D6C86E000DCFB9E /* PurchaseReminderUseCaseTests.swift in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		8A273C861E89689300B42A82 /* EnqueuingCallHistoryCallMakeUseCaseFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A273C851E89689300B42A82 /* EnqueuingCallHistoryCallMakeUseCaseFactory.swift */; };
 		8A2758721EF1850E002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2758711EF1850E002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutputTests.swift */; };
 		8A2758741EF1855C002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2758731EF1855C002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutput.swift */; };
+		8A2851452049E6FF00D7AFFE /* MusicPlayerCallEventTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2851442049E6FF00D7AFFE /* MusicPlayerCallEventTargetTests.swift */; };
+		8A2851472049E74600D7AFFE /* MusicPlayerCallEventTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2851462049E74600D7AFFE /* MusicPlayerCallEventTarget.swift */; };
 		8A2BAAE01F06C1E700A1801E /* FallingBackMatchedContactFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BAADF1F06C1E700A1801E /* FallingBackMatchedContactFactoryTests.swift */; };
 		8A2BAAE21F06C97800A1801E /* FallingBackMatchedContactFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2BAAE11F06C97800A1801E /* FallingBackMatchedContactFactory.swift */; };
 		8A2C042C1F16A44700C46693 /* CallHistoryTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C042B1F16A44700C46693 /* CallHistoryTableRowView.swift */; };
@@ -890,6 +892,8 @@
 		8A273C851E89689300B42A82 /* EnqueuingCallHistoryCallMakeUseCaseFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnqueuingCallHistoryCallMakeUseCaseFactory.swift; sourceTree = "<group>"; };
 		8A2758711EF1850E002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutputTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EnqueuingContactCallHistoryRecordGetUseCaseOutputTests.swift; path = UseCasesTests/EnqueuingContactCallHistoryRecordGetUseCaseOutputTests.swift; sourceTree = SOURCE_ROOT; };
 		8A2758731EF1855C002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnqueuingContactCallHistoryRecordGetUseCaseOutput.swift; sourceTree = "<group>"; };
+		8A2851442049E6FF00D7AFFE /* MusicPlayerCallEventTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MusicPlayerCallEventTargetTests.swift; path = UseCasesTests/MusicPlayerCallEventTargetTests.swift; sourceTree = SOURCE_ROOT; };
+		8A2851462049E74600D7AFFE /* MusicPlayerCallEventTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicPlayerCallEventTarget.swift; sourceTree = "<group>"; };
 		8A2BAADF1F06C1E700A1801E /* FallingBackMatchedContactFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FallingBackMatchedContactFactoryTests.swift; path = UseCasesTests/FallingBackMatchedContactFactoryTests.swift; sourceTree = SOURCE_ROOT; };
 		8A2BAAE11F06C97800A1801E /* FallingBackMatchedContactFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FallingBackMatchedContactFactory.swift; sourceTree = "<group>"; };
 		8A2C042B1F16A44700C46693 /* CallHistoryTableRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallHistoryTableRowView.swift; sourceTree = "<group>"; };
@@ -1897,6 +1901,8 @@
 				8A11B3CF1DDB6D41002EDA93 /* CallHistoryCallEventTargetTests.swift */,
 				8AAFE61C1EE1A2BA00BACC62 /* EnqueuingCallEventTarget.swift */,
 				8AAFE61A1EE1A27800BACC62 /* EnqueuingCallEventTargetTests.swift */,
+				8A2851462049E74600D7AFFE /* MusicPlayerCallEventTarget.swift */,
+				8A2851442049E6FF00D7AFFE /* MusicPlayerCallEventTargetTests.swift */,
 			);
 			name = CallEventTarget;
 			sourceTree = "<group>";
@@ -3895,6 +3901,7 @@
 				8AEF77A41DCB9C0900C73BCB /* CallHistoryRecord.swift in Sources */,
 				AA18F6011C21CD9600FD8E9F /* SettingsSoundIOSaveUseCase.swift in Sources */,
 				8ACD2AE41DD243A300E81984 /* CallHistoryRecordAddUseCase.swift in Sources */,
+				8A2851472049E74600D7AFFE /* MusicPlayerCallEventTarget.swift in Sources */,
 				8AC1A4451C67C390007778A2 /* DefaultSoundPlaybackUseCase.swift in Sources */,
 				8A9084A61EC6108D002B273A /* ContactMatchingSettings.swift in Sources */,
 				AA39054A1BFFE125005A8AA3 /* DomainUserAgentAudioDeviceExtension.swift in Sources */,
@@ -3971,6 +3978,7 @@
 				8ADD6A711CE0DECC001EDBBA /* ProductsEventTargetsTests.swift in Sources */,
 				8A2C9D1E1DD5F73F002367BF /* CallHistoryRecordRemoveUseCaseTests.swift in Sources */,
 				8A61363D1CC23ABC00A087A4 /* SystemAudioDevicesChangeEventTargetsTests.swift in Sources */,
+				8A2851452049E6FF00D7AFFE /* MusicPlayerCallEventTargetTests.swift in Sources */,
 				8ACF85191EE966CC006E88FB /* EnqueuingCallHistoryEventTargetTests.swift in Sources */,
 				8A32D19E1E8E816500903796 /* CallHistoriesHistoryRemoveUseCaseTests.swift in Sources */,
 				8A46FDBB1DD375B50022A822 /* CallHistoryRecordAddUseCaseTests.swift in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -320,8 +320,8 @@
 		8AA748871D6F10C6000587DC /* SettingsAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748821D6DEE61000587DC /* SettingsAccount.swift */; };
 		8AA748931D6F414E000587DC /* AppleMusicPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748921D6F414E000587DC /* AppleMusicPlayer.m */; };
 		8AA748961D6F6D7C000587DC /* SpotifyMusicPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748951D6F6D7C000587DC /* SpotifyMusicPlayer.m */; };
-		8AA748A41D70220D000587DC /* ConditionalMusicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748A31D70220D000587DC /* ConditionalMusicPlayer.swift */; };
-		8AA748A71D702221000587DC /* ConditionalMusicPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748A51D70221F000587DC /* ConditionalMusicPlayerTests.swift */; };
+		8AA748A41D70220D000587DC /* SettingsMusicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748A31D70220D000587DC /* SettingsMusicPlayer.swift */; };
+		8AA748A71D702221000587DC /* SettingsMusicPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748A51D70221F000587DC /* SettingsMusicPlayerTests.swift */; };
 		8AA748A91D7022BA000587DC /* MusicPlayerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748A81D7022BA000587DC /* MusicPlayerSpy.swift */; };
 		8AA748AB1D7023B5000587DC /* MusicPlayerSettingsFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748AA1D7023B5000587DC /* MusicPlayerSettingsFake.swift */; };
 		8AA748AD1D702459000587DC /* MusicPlayerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA748AC1D702459000587DC /* MusicPlayerSettings.swift */; };
@@ -1120,8 +1120,8 @@
 		8AA748921D6F414E000587DC /* AppleMusicPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppleMusicPlayer.m; sourceTree = "<group>"; };
 		8AA748941D6F6D7C000587DC /* SpotifyMusicPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpotifyMusicPlayer.h; sourceTree = "<group>"; };
 		8AA748951D6F6D7C000587DC /* SpotifyMusicPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SpotifyMusicPlayer.m; sourceTree = "<group>"; };
-		8AA748A31D70220D000587DC /* ConditionalMusicPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConditionalMusicPlayer.swift; sourceTree = "<group>"; };
-		8AA748A51D70221F000587DC /* ConditionalMusicPlayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConditionalMusicPlayerTests.swift; path = UseCasesTests/ConditionalMusicPlayerTests.swift; sourceTree = SOURCE_ROOT; };
+		8AA748A31D70220D000587DC /* SettingsMusicPlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsMusicPlayer.swift; sourceTree = "<group>"; };
+		8AA748A51D70221F000587DC /* SettingsMusicPlayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SettingsMusicPlayerTests.swift; path = UseCasesTests/SettingsMusicPlayerTests.swift; sourceTree = SOURCE_ROOT; };
 		8AA748A81D7022BA000587DC /* MusicPlayerSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MusicPlayerSpy.swift; sourceTree = "<group>"; };
 		8AA748AA1D7023B5000587DC /* MusicPlayerSettingsFake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MusicPlayerSettingsFake.swift; sourceTree = "<group>"; };
 		8AA748AC1D702459000587DC /* MusicPlayerSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MusicPlayerSettings.swift; sourceTree = "<group>"; };
@@ -2333,9 +2333,9 @@
 		8AA748B71D70472E000587DC /* MusicPlayer */ = {
 			isa = PBXGroup;
 			children = (
-				8AA748A31D70220D000587DC /* ConditionalMusicPlayer.swift */,
-				8AA748A51D70221F000587DC /* ConditionalMusicPlayerTests.swift */,
 				8A32D1991E8BE7D500903796 /* MusicPlayer.swift */,
+				8AA748A31D70220D000587DC /* SettingsMusicPlayer.swift */,
+				8AA748A51D70221F000587DC /* SettingsMusicPlayerTests.swift */,
 			);
 			name = MusicPlayer;
 			sourceTree = "<group>";
@@ -3787,7 +3787,7 @@
 				8A3D60671C734A8900D7F54C /* NullSoundEventTarget.swift in Sources */,
 				8A645FF51E12C98400515151 /* ContactCallHistoryRecord.swift in Sources */,
 				8A7874F21C5A2612002494ED /* ConditionalRingtonePlaybackUseCase.swift in Sources */,
-				8AA748A41D70220D000587DC /* ConditionalMusicPlayer.swift in Sources */,
+				8AA748A41D70220D000587DC /* SettingsMusicPlayer.swift in Sources */,
 				8AEF77A61DCB9DCD00C73BCB /* CallHistory.swift in Sources */,
 				AA3B6E801C46B40C0030D410 /* Sound.swift in Sources */,
 				8A1AF2641F039C4800B9999D /* EnqueuingContactsChangeEventTarget.swift in Sources */,
@@ -3936,7 +3936,7 @@
 				8AF52BEB1F02A814001F7784 /* SimpleContactMatchingIndexFactoryTests.swift in Sources */,
 				8A1AF2621F039BE800B9999D /* EnqueuingContactsChangeEventTargetTests.swift in Sources */,
 				8A4B65B71EB21CDC00F13654 /* SimpleContactMatchingIndexTests.swift in Sources */,
-				8AA748A71D702221000587DC /* ConditionalMusicPlayerTests.swift in Sources */,
+				8AA748A71D702221000587DC /* SettingsMusicPlayerTests.swift in Sources */,
 				AA7F6D451C0381650064DA3A /* SettingsSoundIOLoadUseCaseTests.swift in Sources */,
 				AA39053D1BFFDDED005A8AA3 /* UserAgentSoundIOSelectionUseCaseTests.swift in Sources */,
 				8ADD6A711CE0DECC001EDBBA /* ProductsEventTargetsTests.swift in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -247,6 +247,11 @@
 		8A7E212D1CC23F6B000D02C3 /* UserAgentAudioDeviceUpdateUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB32A0C1BEB8A760016C8E6 /* UserAgentAudioDeviceUpdateUseCaseTests.swift */; };
 		8A7E21521CC3F6A5000D02C3 /* ServiceAddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7E21511CC3F6A5000D02C3 /* ServiceAddressTests.swift */; };
 		8A7E21541CC411F3000D02C3 /* ServiceAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7E21531CC411F3000D02C3 /* ServiceAddress.swift */; };
+		8A850B3C2049B3120072E197 /* CallsMusicPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B3B2049B3120072E197 /* CallsMusicPlayerTests.swift */; };
+		8A850B3E2049B3740072E197 /* CallsMusicPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B3D2049B3740072E197 /* CallsMusicPlayer.swift */; };
+		8A850B402049B8970072E197 /* ActiveCallsStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B3F2049B8970072E197 /* ActiveCallsStub.swift */; };
+		8A850B422049B94C0072E197 /* Calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B412049B94C0072E197 /* Calls.swift */; };
+		8A850B452049BC410072E197 /* NoActiveCallsStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B442049BC410072E197 /* NoActiveCallsStub.swift */; };
 		8A859A011D2D2BCF00118A66 /* StoreEventSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A859A001D2D2BCF00118A66 /* StoreEventSource.swift */; };
 		8A88B4E71D4A64BF0083958C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE706341D4A2E180060FF4F /* main.swift */; };
 		8A88B4E81D4A666F0083958C /* DefaultNSXPCListenerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE7063A1D4A2F360060FF4F /* DefaultNSXPCListenerDelegate.swift */; };
@@ -1053,6 +1058,11 @@
 		8A7C4F781CD104E300EC7C1B /* PresentationProduct.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PresentationProduct.swift; sourceTree = "<group>"; };
 		8A7E21511CC3F6A5000D02C3 /* ServiceAddressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ServiceAddressTests.swift; path = UseCasesTests/ServiceAddressTests.swift; sourceTree = SOURCE_ROOT; };
 		8A7E21531CC411F3000D02C3 /* ServiceAddress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceAddress.swift; sourceTree = "<group>"; };
+		8A850B3B2049B3120072E197 /* CallsMusicPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CallsMusicPlayerTests.swift; path = UseCasesTests/CallsMusicPlayerTests.swift; sourceTree = SOURCE_ROOT; };
+		8A850B3D2049B3740072E197 /* CallsMusicPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallsMusicPlayer.swift; sourceTree = "<group>"; };
+		8A850B3F2049B8970072E197 /* ActiveCallsStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCallsStub.swift; sourceTree = "<group>"; };
+		8A850B412049B94C0072E197 /* Calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calls.swift; sourceTree = "<group>"; };
+		8A850B442049BC410072E197 /* NoActiveCallsStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoActiveCallsStub.swift; sourceTree = "<group>"; };
 		8A859A001D2D2BCF00118A66 /* StoreEventSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreEventSource.swift; sourceTree = "<group>"; };
 		8A88B4E21D4A5F7C0083958C /* ReceiptValidation.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = ReceiptValidation.entitlements; sourceTree = "<group>"; };
 		8A88B4EF1D4A8D470083958C /* BundleReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleReceipt.swift; sourceTree = "<group>"; };
@@ -1858,13 +1868,14 @@
 			name = Store;
 			sourceTree = "<group>";
 		};
-		8A11B3C81DDB443A002EDA93 /* Call */ = {
+		8A11B3C81DDB443A002EDA93 /* Calls */ = {
 			isa = PBXGroup;
 			children = (
 				8A11B3D51DDB6FDA002EDA93 /* Call */,
 				8A11B3D61DDB6FE8002EDA93 /* CallEventTarget */,
+				8A850B412049B94C0072E197 /* Calls.swift */,
 			);
-			name = Call;
+			name = Calls;
 			sourceTree = "<group>";
 		};
 		8A11B3D51DDB6FDA002EDA93 /* Call */ = {
@@ -2120,6 +2131,15 @@
 			name = ExecutionQueue;
 			sourceTree = "<group>";
 		};
+		8A850B432049BC2E0072E197 /* Calls */ = {
+			isa = PBXGroup;
+			children = (
+				8A850B3F2049B8970072E197 /* ActiveCallsStub.swift */,
+				8A850B442049BC410072E197 /* NoActiveCallsStub.swift */,
+			);
+			name = Calls;
+			sourceTree = "<group>";
+		};
 		8A859A061D2EC66500118A66 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -2333,6 +2353,8 @@
 		8AA748B71D70472E000587DC /* MusicPlayer */ = {
 			isa = PBXGroup;
 			children = (
+				8A850B3D2049B3740072E197 /* CallsMusicPlayer.swift */,
+				8A850B3B2049B3120072E197 /* CallsMusicPlayerTests.swift */,
 				8A32D1991E8BE7D500903796 /* MusicPlayer.swift */,
 				8AA748A31D70220D000587DC /* SettingsMusicPlayer.swift */,
 				8AA748A51D70221F000587DC /* SettingsMusicPlayerTests.swift */,
@@ -2624,7 +2646,7 @@
 			children = (
 				8AA27AD91E97C060002A08CD /* Accounts */,
 				AA39055F1C007799005A8AA3 /* Audio Devices */,
-				8A11B3C81DDB443A002EDA93 /* Call */,
+				8A11B3C81DDB443A002EDA93 /* Calls */,
 				8AEF77A21DCB9BA300C73BCB /* Call History */,
 				8A0CF7931EC0D2EA0014226A /* Contact Matching */,
 				8A4B65B01EB2186300F13654 /* Contacts */,
@@ -2902,6 +2924,7 @@
 				8AD9A0FA1DE71964000BB2F2 /* CallHistoryRecordGetAllUseCaseOutputSpy.swift */,
 				8A143C861DD0D40C00B1CD23 /* CallHistoryRecordTestFactory.swift */,
 				8ACC00291E9D3C85005B0338 /* CallHistorySpy.swift */,
+				8A850B432049BC2E0072E197 /* Calls */,
 				8AAFE61E1EE1A62400BACC62 /* CallTestFactory.swift */,
 				8A7874F51C5A29EE002494ED /* ConditionalRingtonePlaybackUseCaseTestDelegate.swift */,
 				8A41A7561E5DB4F500E0C854 /* ContactCallHistoryRecordGetAllUseCaseOutputSpy.swift */,
@@ -3882,6 +3905,7 @@
 				8A7292271EDDD6F600338592 /* ContactCallHistoryRecordGetAllUseCaseOutput.swift in Sources */,
 				8ACF851B1EE96719006E88FB /* EnqueuingCallHistoryEventTarget.swift in Sources */,
 				8A4D0B001C96D6F8005543A2 /* RingtoneOutputUpdateUseCase.swift in Sources */,
+				8A850B3E2049B3740072E197 /* CallsMusicPlayer.swift in Sources */,
 				8A2BAAE21F06C97800A1801E /* FallingBackMatchedContactFactory.swift in Sources */,
 				8A9D922D1D2AC9B900491D59 /* Products.swift in Sources */,
 				AA39052F1BFFDDDA005A8AA3 /* PreferredSoundIO.swift in Sources */,
@@ -3901,6 +3925,7 @@
 				8A125F791F5857F400148C99 /* PurchaseCheckUseCaseFactory.swift in Sources */,
 				8ADD6A6F1CE0DCF8001EDBBA /* ProductsEventTargets.swift in Sources */,
 				8A2C9D241DD5FBF8002367BF /* CallHistoryRecordRemoveAllUseCase.swift in Sources */,
+				8A850B422049B94C0072E197 /* Calls.swift in Sources */,
 				8A2758741EF1855C002E93D8 /* EnqueuingContactCallHistoryRecordGetUseCaseOutput.swift in Sources */,
 				8ACF85221EEACC07006E88FB /* CallHistoryRecordGetUseCase.swift in Sources */,
 				8AAA5BE51DA695D2005A7BFE /* ReceiptRefreshUseCase.swift in Sources */,
@@ -3982,6 +4007,7 @@
 				8A7E212D1CC23F6B000D02C3 /* UserAgentAudioDeviceUpdateUseCaseTests.swift in Sources */,
 				8A1B27CF1F509B83001B55A7 /* RecordCountingPurchaseCheckUseCaseTests.swift in Sources */,
 				8AA265D81ECDFB6C00813A91 /* NormalizedLowercasedStringTests.swift in Sources */,
+				8A850B3C2049B3120072E197 /* CallsMusicPlayerTests.swift in Sources */,
 				8A11B3D01DDB6D41002EDA93 /* CallHistoryCallEventTargetTests.swift in Sources */,
 				8A125F861F59B92B00148C99 /* EnqueuingCallHistoryRecordGetAllUseCaseOutputTests.swift in Sources */,
 				8A2C9D221DD5FAC1002367BF /* CallHistoryRecordRemoveAllUseCaseTests.swift in Sources */,
@@ -4180,6 +4206,7 @@
 				8ADED1E11EFD7F85009558E0 /* ContactMatchingIndexStub.swift in Sources */,
 				8A9513EE1D2A76F90034DF2C /* ValidReceipt.swift in Sources */,
 				8A7874F61C5A29EE002494ED /* ConditionalRingtonePlaybackUseCaseTestDelegate.swift in Sources */,
+				8A850B402049B8970072E197 /* ActiveCallsStub.swift in Sources */,
 				8A92B7B81E784BC200922B1E /* CallHistoryRecordRemoveUseCaseFactorySpy.swift in Sources */,
 				8AD805801E9E7C6D003089DF /* PropertyListStorageSpy.swift in Sources */,
 				8AEF3B3D1E855DB100F183A8 /* AccountSpy.swift in Sources */,
@@ -4189,6 +4216,7 @@
 				AA7F6D301C0217020064DA3A /* UserAgentEventTargetSpy.swift in Sources */,
 				8A9D922F1D2AE14A00491D59 /* SuccessfulFetchProductsFake.swift in Sources */,
 				8A11A0D11CCFA8B5007BFC7F /* ProductsFetchUseCaseOutputSpy.swift in Sources */,
+				8A850B452049BC410072E197 /* NoActiveCallsStub.swift in Sources */,
 				8AB677F81F0BFD1E001A47A2 /* ContactCallHistoryRecordGetUseCaseOutputSpy.swift in Sources */,
 				8ACC002A1E9D3C85005B0338 /* CallHistorySpy.swift in Sources */,
 				8AE396F01D6C887F00DCFB9E /* PurchaseReminderUseCaseOutputSpy.swift in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 		8AD6597F1D37C987008A1007 /* StoreViewEventTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD6597E1D37C987008A1007 /* StoreViewEventTarget.swift */; };
 		8AD659801D37C987008A1007 /* StoreViewEventTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD6597E1D37C987008A1007 /* StoreViewEventTarget.swift */; };
 		8AD805801E9E7C6D003089DF /* PropertyListStorageSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD8057F1E9E7C6D003089DF /* PropertyListStorageSpy.swift */; };
-		8AD805861E9FD8F6003089DF /* AccountToAccountControllerAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD805851E9FD8F6003089DF /* AccountToAccountControllerAdapter.m */; };
+		8AD805861E9FD8F6003089DF /* AccountControllerToAccountAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD805851E9FD8F6003089DF /* AccountControllerToAccountAdapter.m */; };
 		8AD9A0D21DDF76DE000BB2F2 /* SimpleApplicationDataLocations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9A0D11DDF76DE000BB2F2 /* SimpleApplicationDataLocations.swift */; };
 		8AD9A0D41DDF83A2000BB2F2 /* ApplicationDataLocations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9A0D31DDF83A2000BB2F2 /* ApplicationDataLocations.swift */; };
 		8AD9A0D81DDF8400000BB2F2 /* DirectoryCreatingApplicationDataLocations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9A0D71DDF8400000BB2F2 /* DirectoryCreatingApplicationDataLocations.swift */; };
@@ -1241,8 +1241,8 @@
 		8AD6597B1D36A152008A1007 /* LoggingStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingStore.swift; sourceTree = "<group>"; };
 		8AD6597E1D37C987008A1007 /* StoreViewEventTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreViewEventTarget.swift; sourceTree = "<group>"; };
 		8AD8057F1E9E7C6D003089DF /* PropertyListStorageSpy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertyListStorageSpy.swift; sourceTree = "<group>"; };
-		8AD805841E9FD8F6003089DF /* AccountToAccountControllerAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountToAccountControllerAdapter.h; sourceTree = "<group>"; };
-		8AD805851E9FD8F6003089DF /* AccountToAccountControllerAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccountToAccountControllerAdapter.m; sourceTree = "<group>"; };
+		8AD805841E9FD8F6003089DF /* AccountControllerToAccountAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountControllerToAccountAdapter.h; sourceTree = "<group>"; };
+		8AD805851E9FD8F6003089DF /* AccountControllerToAccountAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccountControllerToAccountAdapter.m; sourceTree = "<group>"; };
 		8AD9A0D11DDF76DE000BB2F2 /* SimpleApplicationDataLocations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleApplicationDataLocations.swift; sourceTree = "<group>"; };
 		8AD9A0D31DDF83A2000BB2F2 /* ApplicationDataLocations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationDataLocations.swift; sourceTree = "<group>"; };
 		8AD9A0D71DDF8400000BB2F2 /* DirectoryCreatingApplicationDataLocations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectoryCreatingApplicationDataLocations.swift; sourceTree = "<group>"; };
@@ -3005,8 +3005,8 @@
 				8A1AA7D41F473DC800804280 /* AccountViewController.m */,
 				8A6BA7A91F3CB110001EB8C1 /* AccountWindowController.h */,
 				8A6BA7AA1F3CB110001EB8C1 /* AccountWindowController.m */,
-				8AD805841E9FD8F6003089DF /* AccountToAccountControllerAdapter.h */,
-				8AD805851E9FD8F6003089DF /* AccountToAccountControllerAdapter.m */,
+				8AD805841E9FD8F6003089DF /* AccountControllerToAccountAdapter.h */,
+				8AD805851E9FD8F6003089DF /* AccountControllerToAccountAdapter.m */,
 				AAF633681056FEA600CF6C3B /* ActiveAccountViewController.h */,
 				AAF633691056FEA600CF6C3B /* ActiveAccountViewController.m */,
 			);
@@ -3655,7 +3655,7 @@
 				8AD9A0DE1DE34ECE000BB2F2 /* TruncatingCallHistoryFactory.swift in Sources */,
 				8AA748C11D704B9F000587DC /* AvailableMusicPlayers.swift in Sources */,
 				AACC029E1C15DCB100913D7B /* SoundIOPresenter.swift in Sources */,
-				8AD805861E9FD8F6003089DF /* AccountToAccountControllerAdapter.m in Sources */,
+				8AD805861E9FD8F6003089DF /* AccountControllerToAccountAdapter.m in Sources */,
 				AA6989A31C19AF150067BFB1 /* DefaultSoundPreferencesViewEventTarget.swift in Sources */,
 				8AD9A0D41DDF83A2000BB2F2 /* ApplicationDataLocations.swift in Sources */,
 				AAECDE8F0E70703100CEAE7B /* AKNSString+Scanning.m in Sources */,

--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		8A850B402049B8970072E197 /* ActiveCallsStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B3F2049B8970072E197 /* ActiveCallsStub.swift */; };
 		8A850B422049B94C0072E197 /* Calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B412049B94C0072E197 /* Calls.swift */; };
 		8A850B452049BC410072E197 /* NoActiveCallsStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B442049BC410072E197 /* NoActiveCallsStub.swift */; };
+		8A850B472049C64B0072E197 /* AKSIPUserAgent+Calls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A850B462049C64B0072E197 /* AKSIPUserAgent+Calls.swift */; };
 		8A859A011D2D2BCF00118A66 /* StoreEventSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A859A001D2D2BCF00118A66 /* StoreEventSource.swift */; };
 		8A88B4E71D4A64BF0083958C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE706341D4A2E180060FF4F /* main.swift */; };
 		8A88B4E81D4A666F0083958C /* DefaultNSXPCListenerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE7063A1D4A2F360060FF4F /* DefaultNSXPCListenerDelegate.swift */; };
@@ -1063,6 +1064,7 @@
 		8A850B3F2049B8970072E197 /* ActiveCallsStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCallsStub.swift; sourceTree = "<group>"; };
 		8A850B412049B94C0072E197 /* Calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calls.swift; sourceTree = "<group>"; };
 		8A850B442049BC410072E197 /* NoActiveCallsStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoActiveCallsStub.swift; sourceTree = "<group>"; };
+		8A850B462049C64B0072E197 /* AKSIPUserAgent+Calls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AKSIPUserAgent+Calls.swift"; sourceTree = "<group>"; };
 		8A859A001D2D2BCF00118A66 /* StoreEventSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreEventSource.swift; sourceTree = "<group>"; };
 		8A88B4E21D4A5F7C0083958C /* ReceiptValidation.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = ReceiptValidation.entitlements; sourceTree = "<group>"; };
 		8A88B4EF1D4A8D470083958C /* BundleReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleReceipt.swift; sourceTree = "<group>"; };
@@ -3077,6 +3079,7 @@
 				AAE33B0F1BA7217C00C6E48B /* AKSIPUserAgentDelegate.h */,
 				AAC0FFC01BE38CEE00A5C7E5 /* AKSIPUserAgentNotifications.h */,
 				AAC0FFC11BE38CEE00A5C7E5 /* AKSIPUserAgentNotifications.m */,
+				8A850B462049C64B0072E197 /* AKSIPUserAgent+Calls.swift */,
 				AA2C03F41BD7D827001D25F9 /* AKSIPUserAgent+UserAgent.swift */,
 				AA4BD4DC0E07C51E005A71B2 /* AKSIPAccount.h */,
 				AA4BD4DD0E07C51E005A71B2 /* AKSIPAccount.m */,
@@ -3726,6 +3729,7 @@
 				8A42E0C51E168DB300CE09B8 /* ShortRelativeDateTimeFormatter.swift in Sources */,
 				8AD6597F1D37C987008A1007 /* StoreViewEventTarget.swift in Sources */,
 				AAF6336A1056FEA600CF6C3B /* ActiveAccountViewController.m in Sources */,
+				8A850B472049C64B0072E197 /* AKSIPUserAgent+Calls.swift in Sources */,
 				AA3F656A1072C926000511E8 /* AuthenticationFailureController.m in Sources */,
 				8AA27AE61E97F0FA002A08CD /* PreferencesControllerNotifications.m in Sources */,
 				8A7C4F711CCFC69F00EC7C1B /* Product+SKProduct.swift in Sources */,

--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -128,6 +128,7 @@ extern const NSInteger kAKSIPAccountDefaultReregistrationTime;
 - (nullable AKSIPCall *)callWithIdentifier:(NSInteger)identifier;
 - (void)removeCall:(AKSIPCall *)call;
 - (void)removeAllCalls;
+- (NSInteger)activeCallsCount;
 
 @end
 

--- a/Telephone/AKSIPAccount.m
+++ b/Telephone/AKSIPAccount.m
@@ -314,6 +314,16 @@ NS_ASSUME_NONNULL_END
     [self.calls removeAllObjects];
 }
 
+- (NSInteger)activeCallsCount {
+    NSInteger count = 0;
+    for (AKSIPCall *call in self.calls) {
+        if (call.isActive) {
+            count++;
+        }
+    }
+    return count;
+}
+
 @end
 
 @implementation AKSIPCallParameters

--- a/Telephone/AKSIPUserAgent+Calls.swift
+++ b/Telephone/AKSIPUserAgent+Calls.swift
@@ -1,5 +1,5 @@
 //
-//  AKSIPUserAgent+UserAgent.swift
+//  AKSIPUserAgent+Calls.swift
 //  Telephone
 //
 //  Copyright © 2008-2016 Alexey Kuznetsov
@@ -18,19 +18,8 @@
 
 import UseCases
 
-extension AKSIPUserAgent: UserAgent {
-    public func audioDevices() throws -> [UserAgentAudioDevice] {
-        if isStarted {
-            return try UserAgentAudioDevices().all
-        } else {
-            throw UserAgentError.userAgentNotStarted
-        }
-    }
-
-    public func selectSoundIODeviceIDs(input: Int, output: Int) throws {
-        let success = self.setSoundInputDevice(input, soundOutputDevice: output)
-        if !success {
-            throw UserAgentError.soundIOSelectionError
-        }
+extension AKSIPUserAgent: Calls {
+    public var haveActive: Bool {
+        return isStarted && activeCallsCount > 0
     }
 }

--- a/Telephone/AKSIPUserAgent.h
+++ b/Telephone/AKSIPUserAgent.h
@@ -80,7 +80,7 @@ extern const NSInteger kAKSIPUserAgentInvalidIdentifier;
 @property(nonatomic, assign) AKNATType detectedNATType;
 
 // The number of acitve calls controlled by the receiver.
-@property(nonatomic, readonly, assign) NSUInteger activeCallsCount;
+@property(nonatomic, readonly, assign) NSInteger activeCallsCount;
 
 // Receiver's call data.
 @property(nonatomic, readonly, assign) AKSIPUserAgentCallData *callData;

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -122,8 +122,12 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     return self.state == AKSIPUserAgentStateStarted;
 }
 
-- (NSUInteger)activeCallsCount {
-    return pjsua_call_get_count();
+- (NSInteger)activeCallsCount {
+    NSInteger count = 0;
+    for (AKSIPAccount *account in self.accounts) {
+        count += [account activeCallsCount];
+    }
+    return count;
 }
 
 - (AKSIPUserAgentCallData *)callData {

--- a/Telephone/AccountController.h
+++ b/Telephone/AccountController.h
@@ -28,13 +28,12 @@ extern NSString * const kEmailSIPLabel;
 @class AKSIPURI, AKNetworkReachability;
 @class AsyncCallHistoryPurchaseCheckUseCaseFactory, AsyncCallHistoryViewEventTargetFactory;
 @class CallTransferController, SanitizedCallDestination, StoreWindowPresenter, WorkspaceSleepStatus;
-@protocol MusicPlayer, RingtonePlaybackUseCase;
+@protocol RingtonePlaybackUseCase;
 
 @interface AccountController : NSObject <AKSIPAccountDelegate, CallControllerDelegate>
 
 @property(nonatomic, readonly) AKSIPAccount *account;
 @property(nonatomic, readonly) id<RingtonePlaybackUseCase> ringtonePlayback;
-@property(nonatomic, readonly) id<MusicPlayer> musicPlayer;
 
 @property(nonatomic, getter=isEnabled) BOOL enabled;
 @property(nonatomic, readonly, getter=isAccountRegistered) BOOL accountRegistered;
@@ -55,7 +54,6 @@ extern NSString * const kEmailSIPLabel;
                 accountDescription:(NSString *)accountDescription
                          userAgent:(AKSIPUserAgent *)userAgent
                   ringtonePlayback:(id<RingtonePlaybackUseCase>)ringtonePlayback
-                       musicPlayer:(id<MusicPlayer>)musicPlayer
                        sleepStatus:(WorkspaceSleepStatus *)sleepStatus
  callHistoryViewEventTargetFactory:(AsyncCallHistoryViewEventTargetFactory *)callHistoryViewEventTargetFactory
        purchaseCheckUseCaseFactory:(AsyncCallHistoryPurchaseCheckUseCaseFactory *)purchaseCheckUseCaseFactory

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -181,7 +181,6 @@ static NSString * const kRussian = @"ru";
                 accountDescription:(NSString *)accountDescription
                          userAgent:(AKSIPUserAgent *)userAgent
                   ringtonePlayback:(id<RingtonePlaybackUseCase>)ringtonePlayback
-                       musicPlayer:(id<MusicPlayer>)musicPlayer
                        sleepStatus:(WorkspaceSleepStatus *)sleepStatus
  callHistoryViewEventTargetFactory:(AsyncCallHistoryViewEventTargetFactory *)callHistoryViewEventTargetFactory
        purchaseCheckUseCaseFactory:(AsyncCallHistoryPurchaseCheckUseCaseFactory *)purchaseCheckUseCaseFactory
@@ -196,7 +195,6 @@ static NSString * const kRussian = @"ru";
     _account.delegate = self;
     _userAgent = userAgent;
     _ringtonePlayback = ringtonePlayback;
-    _musicPlayer = musicPlayer;
     _sleepStatus = sleepStatus;
 
     _callControllers = [[NSMutableArray alloc] init];
@@ -296,7 +294,6 @@ static NSString * const kRussian = @"ru";
                                                       accountController:self
                                                               userAgent:self.userAgent
                                                        ringtonePlayback:self.ringtonePlayback
-                                                            musicPlayer:self.musicPlayer
                                                                delegate:self];
     } else {
         aCallController = callTransferController;
@@ -626,13 +623,10 @@ static NSString * const kRussian = @"ru";
         }
     }
     
-    [self.musicPlayer pause];
-    
     CallController *aCallController = [[CallController alloc] initWithWindowNibName:@"Call"
                                                                   accountController:self
                                                                           userAgent:self.userAgent
                                                                    ringtonePlayback:self.ringtonePlayback
-                                                                        musicPlayer:self.musicPlayer
                                                                            delegate:self];
     
     [aCallController setCall:aCall];

--- a/Telephone/AccountController.m
+++ b/Telephone/AccountController.m
@@ -28,7 +28,7 @@
 #import "AKSIPURIFormatter.h"
 #import "AKTelephoneNumberFormatter.h"
 
-#import "AccountToAccountControllerAdapter.h"
+#import "AccountControllerToAccountAdapter.h"
 #import "AccountViewController.h"
 #import "AccountWindowController.h"
 #import "ActiveAccountViewController.h"
@@ -208,7 +208,7 @@ static NSString * const kRussian = @"ru";
                                                callHistoryViewController:[[CallHistoryViewController alloc] init]
                                        callHistoryViewEventTargetFactory:callHistoryViewEventTargetFactory
                                              purchaseCheckUseCaseFactory:purchaseCheckUseCaseFactory
-                                                                 account:[[AccountToAccountControllerAdapter alloc] initWithController:self]
+                                                                 account:[[AccountControllerToAccountAdapter alloc] initWithController:self]
                                                     storeWindowPresenter:storeWindowPresenter];
     _windowController = [[AccountWindowController alloc] initWithAccountDescription:_accountDescription
                                                                          SIPAddress:_account.SIPAddress

--- a/Telephone/AccountControllerToAccountAdapter.h
+++ b/Telephone/AccountControllerToAccountAdapter.h
@@ -1,5 +1,5 @@
 //
-//  AccountToAccountControllerAdapter.h
+//  AccountControllerToAccountAdapter.h
 //  Telephone
 //
 //  Copyright © 2008-2016 Alexey Kuznetsov
@@ -20,7 +20,7 @@
 
 #import "AccountController.h"
 
-@interface AccountToAccountControllerAdapter : NSObject <Account>
+@interface AccountControllerToAccountAdapter : NSObject <Account>
 
 - (instancetype)initWithController:(AccountController *)controller;
 

--- a/Telephone/AccountControllerToAccountAdapter.m
+++ b/Telephone/AccountControllerToAccountAdapter.m
@@ -1,5 +1,5 @@
 //
-//  AccountToAccountControllerAdapter.m
+//  AccountControllerToAccountAdapter.m
 //  Telephone
 //
 //  Copyright © 2008-2016 Alexey Kuznetsov
@@ -16,17 +16,17 @@
 //  GNU General Public License for more details.
 //
 
-#import "AccountToAccountControllerAdapter.h"
+#import "AccountControllerToAccountAdapter.h"
 
 #import "AKSIPURI.h"
 
-@interface AccountToAccountControllerAdapter ()
+@interface AccountControllerToAccountAdapter ()
 
 @property(nonatomic, nullable, weak, readonly) AccountController *controller;
 
 @end
 
-@implementation AccountToAccountControllerAdapter
+@implementation AccountControllerToAccountAdapter
 
 - (instancetype)initWithController:(AccountController *)controller {
     if ((self = [super init])) {

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -73,7 +73,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) PreferencesController *preferencesController;
 @property(nonatomic, readonly) StoreWindowPresenter *storeWindowPresenter;
 @property(nonatomic, readonly) id<RingtonePlaybackUseCase> ringtonePlayback;
-@property(nonatomic, readonly) id<MusicPlayer> musicPlayer;
 @property(nonatomic, readonly) WorkspaceSleepStatus *sleepStatus;
 @property(nonatomic, readonly) AsyncCallHistoryViewEventTargetFactory *callHistoryViewEventTargetFactory;
 @property(nonatomic, readonly) AsyncCallHistoryPurchaseCheckUseCaseFactory *purchaseCheckUseCaseFactory;
@@ -224,7 +223,6 @@ NS_ASSUME_NONNULL_END
     _preferencesController = _compositionRoot.preferencesController;
     _storeWindowPresenter = _compositionRoot.storeWindowPresenter;
     _ringtonePlayback = _compositionRoot.ringtonePlayback;
-    _musicPlayer = _compositionRoot.musicPlayer;
     _sleepStatus = _compositionRoot.workstationSleepStatus;
     _callHistoryViewEventTargetFactory = _compositionRoot.callHistoryViewEventTargetFactory;
     _purchaseCheckUseCaseFactory = _compositionRoot.callHistoryPurchaseCheckUseCaseFactory;
@@ -787,7 +785,6 @@ NS_ASSUME_NONNULL_END
                                                                accountDescription:account.SIPAddress
                                                                         userAgent:self.userAgent
                                                                  ringtonePlayback:self.ringtonePlayback
-                                                                      musicPlayer:self.musicPlayer
                                                                       sleepStatus:self.sleepStatus
                                                 callHistoryViewEventTargetFactory:self.callHistoryViewEventTargetFactory
                                                       purchaseCheckUseCaseFactory:self.purchaseCheckUseCaseFactory
@@ -854,7 +851,6 @@ NS_ASSUME_NONNULL_END
                                                                    accountDescription:description
                                                                             userAgent:self.userAgent
                                                                      ringtonePlayback:self.ringtonePlayback
-                                                                          musicPlayer:self.musicPlayer
                                                                           sleepStatus:self.sleepStatus
                                                     callHistoryViewEventTargetFactory:self.callHistoryViewEventTargetFactory
                                                           purchaseCheckUseCaseFactory:self.purchaseCheckUseCaseFactory
@@ -1144,7 +1140,6 @@ NS_ASSUME_NONNULL_END
                                                                    accountDescription:description
                                                                             userAgent:self.userAgent
                                                                      ringtonePlayback:self.ringtonePlayback
-                                                                          musicPlayer:self.musicPlayer
                                                                           sleepStatus:self.sleepStatus
                                                     callHistoryViewEventTargetFactory:self.callHistoryViewEventTargetFactory
                                                           purchaseCheckUseCaseFactory:self.purchaseCheckUseCaseFactory

--- a/Telephone/AvailableMusicPlayers.swift
+++ b/Telephone/AvailableMusicPlayers.swift
@@ -32,11 +32,11 @@ final class AvailableMusicPlayers {
 }
 
 extension AvailableMusicPlayers: MusicPlayer {
-    @objc func pause() {
+    func pause() {
         players.pause()
     }
 
-    @objc func resume() {
+    func resume() {
         players.resume()
     }
 }

--- a/Telephone/CallController.h
+++ b/Telephone/CallController.h
@@ -26,7 +26,7 @@
 @class AccountController, AKSIPCall, AKSIPURI, AKSIPUserAgent;
 @class IncomingCallViewController, ActiveCallViewController;
 @class EndedCallViewController, CallTransferController;
-@protocol MusicPlayer, RingtonePlaybackUseCase;
+@protocol RingtonePlaybackUseCase;
 
 // A call controller.
 @interface CallController : NSWindowController <AKSIPCallDelegate> {
@@ -99,7 +99,6 @@
                     accountController:(AccountController *)accountController
                             userAgent:(AKSIPUserAgent *)userAgent
                      ringtonePlayback:(id<RingtonePlaybackUseCase>)ringtonePlayback
-                          musicPlayer:(id<MusicPlayer>)musicPlayer
                              delegate:(id<CallControllerDelegate>)delegate;
 
 // Accepts an incoming call.

--- a/Telephone/CallController.m
+++ b/Telephone/CallController.m
@@ -47,7 +47,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
 
 @property(nonatomic, readonly) AKSIPUserAgent *userAgent;
 @property(nonatomic, readonly) id<RingtonePlaybackUseCase> ringtonePlayback;
-@property(nonatomic, readonly) id<MusicPlayer> musicPlayer;
 
 // Account description field.
 @property(nonatomic, weak) IBOutlet NSTextField *accountDescriptionField;
@@ -123,7 +122,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
                     accountController:(AccountController *)accountController
                             userAgent:(AKSIPUserAgent *)userAgent
                      ringtonePlayback:(id<RingtonePlaybackUseCase>)ringtonePlayback
-                          musicPlayer:(id<MusicPlayer>)musicPlayer
                              delegate:(id<CallControllerDelegate>)delegate {
 
     if ((self = [self initWithWindowNibName:windowNibName])) {
@@ -131,7 +129,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
         _accountController = accountController;
         _userAgent = userAgent;
         _ringtonePlayback = ringtonePlayback;
-        _musicPlayer = musicPlayer;
         _delegate = delegate;
     }
     return self;
@@ -231,8 +228,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
     [[[self incomingCallViewController] acceptCallButton] setEnabled:NO];
     [[[self incomingCallViewController] declineCallButton] setEnabled:NO];
     
-    [self.musicPlayer resume];
-
     // Optionally close call window.
     if ([[NSUserDefaults standardUserDefaults] boolForKey:kAutoCloseCallWindow] &&
         ![self isKindOfClass:[CallTransferController class]]) {
@@ -449,8 +444,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
         }
         
         [[self call] hangUp];
-        
-        [self.musicPlayer resume];
     }
     
     [self.delegate callControllerWillClose:self];
@@ -465,7 +458,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
 #pragma mark AKSIPCallDelegate
 
 - (void)SIPCallEarly:(NSNotification *)notification {
-    [self.musicPlayer pause];
     if (![[self call] isIncoming]) {
         NSNumber *sipEventCode = [notification userInfo][@"AKSIPEventCode"];
         if ([sipEventCode isEqualToNumber:@(PJSIP_SC_RINGING)]) {
@@ -477,8 +469,7 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
 
 - (void)SIPCallDidConfirm:(NSNotification *)notification {
     [self setCallStartTime:[NSDate timeIntervalSinceReferenceDate]];
-    [self.musicPlayer pause];
-    
+
     if ([[notification object] isIncoming]) {
         [self.ringtonePlayback stop];
     }
@@ -556,8 +547,6 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
                                    userInfo:nil
                                     repeats:NO];
     
-    [self.musicPlayer resume];
-
     [self removeOrShowUserNotificationIfNeeded];
     
     // Optionally close disconnected call window.

--- a/Telephone/CallNotificationsToEventTargetAdapter.swift
+++ b/Telephone/CallNotificationsToEventTargetAdapter.swift
@@ -26,11 +26,21 @@ final class CallNotificationsToEventTargetAdapter {
     init(center: NotificationCenter, target: CallEventTarget) {
         self.center = center
         self.target = target
+        center.addObserver(self, selector: #selector(didMake), name: .AKSIPCallCalling, object: nil)
+        center.addObserver(self, selector: #selector(didReceive), name: .AKSIPCallIncoming, object: nil)
         center.addObserver(self, selector: #selector(didDisconnect), name: .AKSIPCallDidDisconnect, object: nil)
     }
 
     deinit {
-        center.removeObserver(self, name: .AKSIPCallDidDisconnect, object: nil)
+        center.removeObserver(self)
+    }
+
+    @objc private func didMake(_ notification: Notification) {
+        target.didMake(notification.object as! Call)
+    }
+
+    @objc private func didReceive(_ notification: Notification) {
+        target.didReceive(notification.object as! Call)
     }
 
     @objc private func didDisconnect(_ notification: Notification) {

--- a/Telephone/CallTransferController.m
+++ b/Telephone/CallTransferController.m
@@ -74,7 +74,6 @@
                           accountController:accountController
                                   userAgent:userAgent
                            ringtonePlayback:accountController.ringtonePlayback
-                                musicPlayer:accountController.musicPlayer
                                    delegate:accountController])) {
         [self setSourceCallController:callController];
         _activeAccountTransferViewController = [[ActiveAccountTransferViewController alloc] initWithAccountController:accountController];

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -197,7 +197,8 @@ final class CompositionRoot: NSObject {
                 origin: CallHistoryCallEventTarget(
                     histories: callHistories, factory: DefaultCallHistoryRecordAddUseCaseFactory()
                 ),
-                queue: contactsBackground)
+                queue: contactsBackground
+            )
         )
 
         let contactMatchingSettings = SimpleContactMatchingSettings(settings: defaults)

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -125,7 +125,7 @@ final class CompositionRoot: NSObject {
         )
 
         musicPlayer = SettingsMusicPlayer(
-            origin: AvailableMusicPlayers(factory: MusicPlayerFactory()),
+            origin: CallsMusicPlayer(origin: AvailableMusicPlayers(factory: MusicPlayerFactory()), calls: userAgent),
             settings: SimpleMusicPlayerSettings(settings: defaults)
         )
 

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -123,7 +123,7 @@ final class CompositionRoot: NSObject {
             )
         )
 
-        musicPlayer = ConditionalMusicPlayer(
+        musicPlayer = SettingsMusicPlayer(
             origin: AvailableMusicPlayers(factory: MusicPlayerFactory()),
             settings: SimpleMusicPlayerSettings(settings: defaults)
         )

--- a/Telephone/CompositionRoot.swift
+++ b/Telephone/CompositionRoot.swift
@@ -108,7 +108,8 @@ final class CompositionRoot: NSObject {
 
         let userAgentSoundIOSelection = DelayingUserAgentSoundIOSelectionUseCase(
             useCase: UserAgentSoundIOSelectionUseCase(repository: audioDevices, userAgent: userAgent, settings: defaults),
-            userAgent: userAgent
+            agent: userAgent,
+            calls: userAgent
         )
 
         preferencesController = PreferencesController(

--- a/Telephone/MusicPlayers.swift
+++ b/Telephone/MusicPlayers.swift
@@ -27,11 +27,11 @@ final class MusicPlayers {
 }
 
 extension MusicPlayers: MusicPlayer {
-    @objc func pause() {
+    func pause() {
         players.forEach { $0.pause() }
     }
 
-    @objc func resume() {
+    func resume() {
         players.forEach { $0.resume() }
     }
 }

--- a/UseCases/CallEventTarget.swift
+++ b/UseCases/CallEventTarget.swift
@@ -17,5 +17,7 @@
 //
 
 public protocol CallEventTarget {
+    func didMake(_ call: Call)
+    func didReceive(_ call: Call)
     func didDisconnect(_ call: Call)
 }

--- a/UseCases/CallEventTargets.swift
+++ b/UseCases/CallEventTargets.swift
@@ -1,0 +1,39 @@
+//
+//  CallEventTargets.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+public final class CallEventTargets {
+    private let targets: [CallEventTarget]
+
+    public init(targets: [CallEventTarget]) {
+        self.targets = targets
+    }
+}
+
+extension CallEventTargets: CallEventTarget {
+    public func didMake(_ call: Call) {
+        targets.forEach { $0.didMake(call) }
+    }
+
+    public func didReceive(_ call: Call) {
+        targets.forEach { $0.didReceive(call) }
+    }
+
+    public func didDisconnect(_ call: Call) {
+        targets.forEach { $0.didDisconnect(call) }
+    }
+}

--- a/UseCases/CallHistoryCallEventTarget.swift
+++ b/UseCases/CallHistoryCallEventTarget.swift
@@ -34,4 +34,7 @@ extension CallHistoryCallEventTarget: CallEventTarget {
             domain: call.account.domain
         ).execute()
     }
+
+    public func didMake(_ call: Call) {}
+    public func didReceive(_ call: Call) {}
 }

--- a/UseCases/Calls.swift
+++ b/UseCases/Calls.swift
@@ -1,0 +1,21 @@
+//
+//  Calls.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+public protocol Calls {
+    var haveActive: Bool { get }
+}

--- a/UseCases/CallsMusicPlayer.swift
+++ b/UseCases/CallsMusicPlayer.swift
@@ -1,0 +1,39 @@
+//
+//  CallsMusicPlayer.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+public final class CallsMusicPlayer {
+    private let origin: MusicPlayer
+    private let calls: Calls
+
+    public init(origin: MusicPlayer, calls: Calls) {
+        self.origin = origin
+        self.calls = calls
+    }
+}
+
+extension CallsMusicPlayer: MusicPlayer {
+    public func pause() {
+        origin.pause()
+    }
+
+    public func resume() {
+        if !calls.haveActive {
+            origin.resume()
+        }
+    }
+}

--- a/UseCases/DelayingUserAgentSoundIOSelectionUseCase.swift
+++ b/UseCases/DelayingUserAgentSoundIOSelectionUseCase.swift
@@ -17,13 +17,16 @@
 //
 
 public final class DelayingUserAgentSoundIOSelectionUseCase {
-    private let useCase: ThrowingUseCase
-    private let userAgent: UserAgent
     private var selection: ThrowingUseCase?
 
-    public init(useCase: ThrowingUseCase, userAgent: UserAgent) {
+    private let useCase: ThrowingUseCase
+    private let agent: UserAgent
+    private let calls: Calls
+
+    public init(useCase: ThrowingUseCase, agent: UserAgent, calls: Calls) {
         self.useCase = useCase
-        self.userAgent = userAgent
+        self.agent = agent
+        self.calls = calls
     }
 }
 
@@ -34,7 +37,7 @@ extension DelayingUserAgentSoundIOSelectionUseCase: UseCase {
     }
 
     private func selectSoundIOOrLogErrorIfNeeded() {
-        if userAgent.hasActiveCalls {
+        if calls.haveActive {
             selectSoundIOOrLogError()
         }
     }

--- a/UseCases/EnqueuingCallEventTarget.swift
+++ b/UseCases/EnqueuingCallEventTarget.swift
@@ -27,6 +27,18 @@ public final class EnqueuingCallEventTarget {
 }
 
 extension EnqueuingCallEventTarget: CallEventTarget {
+    public func didMake(_ call: Call) {
+        queue.add {
+            self.origin.didMake(call)
+        }
+    }
+
+    public func didReceive(_ call: Call) {
+        queue.add {
+            self.origin.didReceive(call)
+        }
+    }
+
     public func didDisconnect(_ call: Call) {
         queue.add {
             self.origin.didDisconnect(call)

--- a/UseCases/EnqueuingCallEventTargetTests.swift
+++ b/UseCases/EnqueuingCallEventTargetTests.swift
@@ -21,6 +21,24 @@ import UseCases
 import UseCasesTestDoubles
 
 final class EnqueuingCallEventTargetTests: XCTestCase {
+    func testAddsBlockToQueueOnDidMake() {
+        let queue = ExecutionQueueSpy()
+        let sut = EnqueuingCallEventTarget(origin: CallEventTargetSpy(), queue: queue)
+
+        sut.didMake(CallTestFactory().make())
+
+        XCTAssertTrue(queue.didCallAdd)
+    }
+
+    func testAddsBockToQueueOnDidReceive() {
+        let queue = ExecutionQueueSpy()
+        let sut = EnqueuingCallEventTarget(origin: CallEventTargetSpy(), queue: queue)
+
+        sut.didReceive(CallTestFactory().make())
+
+        XCTAssertTrue(queue.didCallAdd)
+    }
+
     func testAddsBockToQueueOnDidDisconnect() {
         let queue = ExecutionQueueSpy()
         let sut = EnqueuingCallEventTarget(origin: CallEventTargetSpy(), queue: queue)
@@ -30,6 +48,28 @@ final class EnqueuingCallEventTargetTests: XCTestCase {
         XCTAssertTrue(queue.didCallAdd)
     }
 
+    func testCallsDidMakeOnOriginWithTheSameArgumentOnDidMake() {
+        let origin = CallEventTargetSpy()
+        let sut = EnqueuingCallEventTarget(origin: origin, queue: SyncExecutionQueue())
+        let call = CallTestFactory().make()
+
+        sut.didMake(call)
+
+        XCTAssertTrue(origin.didCallDidMake)
+        XCTAssertTrue(origin.invokedCall === call)
+    }
+
+    func testCallsDidMakeOnOriginWithTheSameArgumentOnDidReceive() {
+        let origin = CallEventTargetSpy()
+        let sut = EnqueuingCallEventTarget(origin: origin, queue: SyncExecutionQueue())
+        let call = CallTestFactory().make()
+
+        sut.didReceive(call)
+
+        XCTAssertTrue(origin.didCallDidReceive)
+        XCTAssertTrue(origin.invokedCall === call)
+    }
+
     func testCallsDidDisconnectOnOriginWithTheSameArgumentOnDidDisconnect() {
         let origin = CallEventTargetSpy()
         let sut = EnqueuingCallEventTarget(origin: origin, queue: SyncExecutionQueue())
@@ -37,6 +77,7 @@ final class EnqueuingCallEventTargetTests: XCTestCase {
 
         sut.didDisconnect(call)
 
+        XCTAssertTrue(origin.didCallDidDisconnect)
         XCTAssertTrue(origin.invokedCall === call)
     }
 }

--- a/UseCases/MusicPlayerCallEventTarget.swift
+++ b/UseCases/MusicPlayerCallEventTarget.swift
@@ -1,5 +1,5 @@
 //
-//  CallEventTargetSpy.swift
+//  MusicPlayerCallEventTarget.swift
 //  Telephone
 //
 //  Copyright © 2008-2016 Alexey Kuznetsov
@@ -16,30 +16,24 @@
 //  GNU General Public License for more details.
 //
 
-import UseCases
+public final class MusicPlayerCallEventTarget {
+    private let player: MusicPlayer
 
-public final class CallEventTargetSpy {
-    public private(set) var didCallDidMake = false
-    public private(set) var didCallDidReceive = false
-    public private(set) var didCallDidDisconnect = false
-    public private(set) var invokedCall: Call?
-
-    public init() {}
+    public init(player: MusicPlayer) {
+        self.player = player
+    }
 }
 
-extension CallEventTargetSpy: CallEventTarget {
+extension MusicPlayerCallEventTarget: CallEventTarget {
     public func didMake(_ call: Call) {
-        didCallDidMake = true
-        invokedCall = call
+        player.pause()
     }
 
     public func didReceive(_ call: Call) {
-        didCallDidReceive = true
-        invokedCall = call
+        player.pause()
     }
 
     public func didDisconnect(_ call: Call) {
-        didCallDidDisconnect = true
-        invokedCall = call
+        player.resume()
     }
 }

--- a/UseCases/SettingsMusicPlayer.swift
+++ b/UseCases/SettingsMusicPlayer.swift
@@ -27,13 +27,13 @@ public final class SettingsMusicPlayer {
 }
 
 extension SettingsMusicPlayer: MusicPlayer {
-    @objc public func pause() {
+    public func pause() {
         if settings.shouldPause {
             origin.pause()
         }
     }
 
-    @objc public func resume() {
+    public func resume() {
         if settings.shouldPause {
             origin.resume()
         }

--- a/UseCases/SettingsMusicPlayer.swift
+++ b/UseCases/SettingsMusicPlayer.swift
@@ -1,5 +1,5 @@
 //
-//  ConditionalMusicPlayer.swift
+//  SettingsMusicPlayer.swift
 //  Telephone
 //
 //  Copyright © 2008-2016 Alexey Kuznetsov
@@ -16,7 +16,7 @@
 //  GNU General Public License for more details.
 //
 
-public final class ConditionalMusicPlayer {
+public final class SettingsMusicPlayer {
     private let origin: MusicPlayer
     private let settings: MusicPlayerSettings
 
@@ -26,7 +26,7 @@ public final class ConditionalMusicPlayer {
     }
 }
 
-extension ConditionalMusicPlayer: MusicPlayer {
+extension SettingsMusicPlayer: MusicPlayer {
     @objc public func pause() {
         if settings.shouldPause {
             origin.pause()

--- a/UseCases/UserAgent.swift
+++ b/UseCases/UserAgent.swift
@@ -20,7 +20,6 @@ import Foundation
 
 @objc public protocol UserAgent {
     var isStarted: Bool { get }
-    var hasActiveCalls: Bool { get }
     func audioDevices() throws -> [UserAgentAudioDevice]
     func updateAudioDevices()
     func selectSoundIODeviceIDs(input: Int, output: Int) throws

--- a/UseCasesTestDoubles/ActiveCallsStub.swift
+++ b/UseCasesTestDoubles/ActiveCallsStub.swift
@@ -1,0 +1,24 @@
+//
+//  ActiveCallsStub.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import UseCases
+
+public final class ActiveCallsStub: Calls {
+    public var haveActive = true
+    public init() {}
+}

--- a/UseCasesTestDoubles/MusicPlayerSpy.swift
+++ b/UseCasesTestDoubles/MusicPlayerSpy.swift
@@ -26,11 +26,11 @@ public final class MusicPlayerSpy {
 }
 
 extension MusicPlayerSpy: MusicPlayer {
-    @objc public func pause() {
+    public func pause() {
         didCallPause = true
     }
 
-    @objc public func resume() {
+    public func resume() {
         didCallResume = true
     }
 }

--- a/UseCasesTestDoubles/NoActiveCallsStub.swift
+++ b/UseCasesTestDoubles/NoActiveCallsStub.swift
@@ -1,0 +1,24 @@
+//
+//  NoActiveCallsStub.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import UseCases
+
+public final class NoActiveCallsStub: Calls {
+    public var haveActive = false
+    public init() {}
+}

--- a/UseCasesTestDoubles/UserAgentSpy.swift
+++ b/UseCasesTestDoubles/UserAgentSpy.swift
@@ -21,7 +21,6 @@ import UseCases
 
 public final class UserAgentSpy: NSObject {
     public var isStarted = false
-    public private(set) var hasActiveCalls = false
 
     public private(set) var didCallAudioDevices = false
     public var audioDevicesResult = [UserAgentAudioDevice]()
@@ -32,10 +31,6 @@ public final class UserAgentSpy: NSObject {
 
     public private(set) var invokedInputDeviceID: Int?
     public private(set) var invokedOutputDeviceID: Int?
-
-    public func simulateActiveCalls() {
-        hasActiveCalls = true
-    }
 }
 
 extension UserAgentSpy: UserAgent {

--- a/UseCasesTests/CallEventTargetsTests.swift
+++ b/UseCasesTests/CallEventTargetsTests.swift
@@ -1,0 +1,65 @@
+//
+//  CallEventTargetsTests.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import UseCases
+import UseCasesTestDoubles
+import XCTest
+
+final class CallEventTargetsTests: XCTestCase {
+    func testCallsDidMakeWithPassedArgumentOnAllTargets() {
+        let first = CallEventTargetSpy()
+        let second = CallEventTargetSpy()
+        let call = CallTestFactory().make()
+        let sut = CallEventTargets(targets: [first, second])
+
+        sut.didMake(call)
+
+        XCTAssertTrue(first.didCallDidMake)
+        XCTAssertTrue(second.didCallDidMake)
+        XCTAssertTrue(first.invokedCall === call)
+        XCTAssertTrue(second.invokedCall === call)
+    }
+
+    func testCallsDidReceiveWithPassedArgumentOnAllTargets() {
+        let first = CallEventTargetSpy()
+        let second = CallEventTargetSpy()
+        let call = CallTestFactory().make()
+        let sut = CallEventTargets(targets: [first, second])
+
+        sut.didReceive(call)
+
+        XCTAssertTrue(first.didCallDidReceive)
+        XCTAssertTrue(second.didCallDidReceive)
+        XCTAssertTrue(first.invokedCall === call)
+        XCTAssertTrue(second.invokedCall === call)
+    }
+
+    func testCallsDidDisconnectWithPassedArgumentOnAllTargets() {
+        let first = CallEventTargetSpy()
+        let second = CallEventTargetSpy()
+        let call = CallTestFactory().make()
+        let sut = CallEventTargets(targets: [first, second])
+
+        sut.didDisconnect(call)
+
+        XCTAssertTrue(first.didCallDidDisconnect)
+        XCTAssertTrue(second.didCallDidDisconnect)
+        XCTAssertTrue(first.invokedCall === call)
+        XCTAssertTrue(second.invokedCall === call)
+    }
+}

--- a/UseCasesTests/CallsMusicPlayerTests.swift
+++ b/UseCasesTests/CallsMusicPlayerTests.swift
@@ -1,0 +1,59 @@
+//
+//  CallsMusicPlayerTests.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import UseCases
+import UseCasesTestDoubles
+import XCTest
+
+final class CallsMusicPlayerTests: XCTestCase {
+    func testResumesWhenThereAreNoActiveCalls() {
+        let origin = MusicPlayerSpy()
+        let sut = CallsMusicPlayer(origin: origin, calls: NoActiveCallsStub())
+
+        sut.resume()
+
+        XCTAssertTrue(origin.didCallResume)
+    }
+
+    func testDoesNotResumeWhenThereAreActiveCalls() {
+        let origin = MusicPlayerSpy()
+        let sut = CallsMusicPlayer(origin: origin, calls: ActiveCallsStub())
+
+        sut.resume()
+
+        XCTAssertFalse(origin.didCallResume)
+    }
+
+    func testPausesWhenThereAreNoActiveCalls() {
+        let origin = MusicPlayerSpy()
+        let sut = CallsMusicPlayer(origin: origin, calls: NoActiveCallsStub())
+
+        sut.pause()
+
+        XCTAssertTrue(origin.didCallPause)
+    }
+
+    func testPausesWhenThereAreActiveCalls() {
+        let origin = MusicPlayerSpy()
+        let sut = CallsMusicPlayer(origin: origin, calls: ActiveCallsStub())
+
+        sut.pause()
+
+        XCTAssertTrue(origin.didCallPause)
+    }
+}

--- a/UseCasesTests/DelayingUserAgentSoundIOSelectionUseCaseTests.swift
+++ b/UseCasesTests/DelayingUserAgentSoundIOSelectionUseCaseTests.swift
@@ -28,8 +28,7 @@ final class DelayingUserAgentSoundIOSelectionUseCaseTests: XCTestCase {
         super.setUp()
         agent = UserAgentSpy()
         sut = DelayingUserAgentSoundIOSelectionUseCase(
-            useCase: UserAgentSoundIOSelectionUseCaseFake(userAgent: agent),
-            userAgent: agent
+            useCase: UserAgentSoundIOSelectionUseCaseFake(userAgent: agent), agent: agent, calls: NoActiveCallsStub()
         )
     }
 
@@ -124,10 +123,13 @@ final class DelayingUserAgentSoundIOSelectionUseCaseTests: XCTestCase {
         XCTAssertEqual(agent.soundIOSelectionCallCount, 2)
     }
 
-    func testSelectsIOOnExecuteWhenUserAgentHasActiveCalls() {
+    func testSelectsIOOnSystemAudioDevicesUpdateWhenThereAreActiveCalls() {
+        let agent = UserAgentSpy()
+        let sut = DelayingUserAgentSoundIOSelectionUseCase(
+            useCase: UserAgentSoundIOSelectionUseCaseFake(userAgent: agent), agent: agent, calls: ActiveCallsStub()
+        )
         sut.didFinishStarting(agent)
         sut.didMakeCall(agent)
-        agent.simulateActiveCalls()
 
         sut.systemAudioDevicesDidUpdate()
 

--- a/UseCasesTests/MusicPlayerCallEventTargetTests.swift
+++ b/UseCasesTests/MusicPlayerCallEventTargetTests.swift
@@ -1,0 +1,50 @@
+//
+//  MusicPlayerCallEventTargetTests.swift
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+import UseCases
+import UseCasesTestDoubles
+import XCTest
+
+final class MusicPlayerCallEventTargetTests: XCTestCase {
+    func testPausesOnDidMake() {
+        let player = MusicPlayerSpy()
+        let sut = MusicPlayerCallEventTarget(player: player)
+
+        sut.didMake(CallTestFactory().make())
+
+        XCTAssertTrue(player.didCallPause)
+    }
+
+    func testPausesOnDidReceive() {
+        let player = MusicPlayerSpy()
+        let sut = MusicPlayerCallEventTarget(player: player)
+
+        sut.didReceive(CallTestFactory().make())
+
+        XCTAssertTrue(player.didCallPause)
+    }
+
+    func testResumesOnDidDisconnect() {
+        let player = MusicPlayerSpy()
+        let sut = MusicPlayerCallEventTarget(player: player)
+
+        sut.didDisconnect(CallTestFactory().make())
+
+        XCTAssertTrue(player.didCallResume)
+    }
+}

--- a/UseCasesTests/SettingsMusicPlayerTests.swift
+++ b/UseCasesTests/SettingsMusicPlayerTests.swift
@@ -1,5 +1,5 @@
 //
-//  ConditionalMusicPlayerTests.swift
+//  SettingsMusicPlayerTests.swift
 //  Telephone
 //
 //  Copyright © 2008-2016 Alexey Kuznetsov
@@ -20,12 +20,12 @@ import UseCases
 import UseCasesTestDoubles
 import XCTest
 
-final class ConditionalMusicPlayerTests: XCTestCase {
+final class SettingsMusicPlayerTests: XCTestCase {
     func testPausesAndResumesWhenEnabledInSettings() {
         let origin = MusicPlayerSpy()
         let settings = MusicPlayerSettingsFake()
         settings.shouldPause = true
-        let sut = ConditionalMusicPlayer(origin: origin, settings: settings)
+        let sut = SettingsMusicPlayer(origin: origin, settings: settings)
 
         sut.pause()
         sut.resume()
@@ -38,7 +38,7 @@ final class ConditionalMusicPlayerTests: XCTestCase {
         let origin = MusicPlayerSpy()
         let settings = MusicPlayerSettingsFake()
         settings.shouldPause = false
-        let sut = ConditionalMusicPlayer(origin: origin, settings: settings)
+        let sut = SettingsMusicPlayer(origin: origin, settings: settings)
 
         sut.pause()
         sut.resume()


### PR DESCRIPTION
When extracting the music player functionality, the number of active calls wasn’t taken into account. This pull request adds this lost logic. Also, the call event handling regarding the music player control is extracted and removed from the call controller.

Closes #429