### PR TITLE
Return NSFontManager to MainMenu.xib

### DIFF
--- a/Telephone/Base.lproj/MainMenu.xib
+++ b/Telephone/Base.lproj/MainMenu.xib
@@ -243,6 +243,7 @@ DQ
                 </menuItem>
             </items>
         </menu>
+        <customObject id="420" customClass="NSFontManager"/>
         <customObject id="450" customClass="AppController">
             <connections>
                 <outlet property="helpMenuActionRedirect" destination="C3A-nH-yvt" id="rn4-r7-Adp"/>


### PR DESCRIPTION
What if it fixes the font panel-related crash on 10.0?

Closes #445