### PR TITLE
Xcode 10

### DIFF
--- a/ReceiptValidation/CertificateFingerprintValidation.swift
+++ b/ReceiptValidation/CertificateFingerprintValidation.swift
@@ -29,7 +29,7 @@ final class CertificateFingerprintValidation: NSObject {
 }
 
 extension CertificateFingerprintValidation: ReceiptValidation {
-    func validateReceipt(_ receipt: Data, completion: (_ result: Result, _ expiration: Date) -> Void) {
+    func validateReceipt(_ receipt: Data, completion: @escaping (_ result: Result, _ expiration: Date) -> Void) {
         if SHA256Fingerprint(source: certificate) == SHA256Fingerprint(sha256: expected) {
             origin.validateReceipt(receipt, completion: completion)
         } else {

--- a/ReceiptValidation/PKCS7ContainerValidation.swift
+++ b/ReceiptValidation/PKCS7ContainerValidation.swift
@@ -27,7 +27,7 @@ final class PKCS7ContainerValidation: NSObject {
 }
 
 extension PKCS7ContainerValidation: ReceiptValidation {
-    func validateReceipt(_ receipt: Data, completion: (_ result: Result, _ expiration: Date) -> Void) {
+    func validateReceipt(_ receipt: Data, completion: @escaping (_ result: Result, _ expiration: Date) -> Void) {
         if let _ = PKCS7Container(data: receipt) {
             origin.validateReceipt(receipt, completion: completion)
         } else {

--- a/ReceiptValidation/PKCS7SignatureValidation.swift
+++ b/ReceiptValidation/PKCS7SignatureValidation.swift
@@ -29,7 +29,7 @@ final class PKCS7SignatureValidation: NSObject {
 }
 
 extension PKCS7SignatureValidation: ReceiptValidation {
-    func validateReceipt(_ receipt: Data, completion: (_ result: Result, _ expiration: Date) -> Void) {
+    func validateReceipt(_ receipt: Data, completion: @escaping (_ result: Result, _ expiration: Date) -> Void) {
         if PKCS7Container(data: receipt)!.isSignatureValid(withRootCertificate: certificate) {
             origin.validateReceipt(receipt, completion: completion)
         } else {

--- a/ReceiptValidation/ReceiptAttributesValidation.swift
+++ b/ReceiptValidation/ReceiptAttributesValidation.swift
@@ -29,7 +29,7 @@ final class ReceiptAttributesValidation: NSObject {
 }
 
 extension ReceiptAttributesValidation: ReceiptValidation {
-    func validateReceipt(_ receipt: Data, completion: (_ result: Result, _ expiration: Date) -> Void) {
+    func validateReceipt(_ receipt: Data, completion: @escaping (_ result: Result, _ expiration: Date) -> Void) {
         if let p = ASN1ReceiptPayload(container: PKCS7Container(data: receipt)!), isReceiptValid(ASN1Receipt(payload: p)) {
             origin.validateReceipt(receipt, completion: completion)
         } else {

--- a/ReceiptValidation/ReceiptValidation.swift
+++ b/ReceiptValidation/ReceiptValidation.swift
@@ -19,5 +19,5 @@
 import Foundation
 
 @objc public protocol ReceiptValidation {
-    func validateReceipt(_ receipt: Data, completion: (_ result: Result, _ expiration: Date) -> Void)
+    func validateReceipt(_ receipt: Data, completion: @escaping (_ result: Result, _ expiration: Date) -> Void)
 }

--- a/Telephone/Base.lproj/StoreViewController.xib
+++ b/Telephone/Base.lproj/StoreViewController.xib
@@ -69,8 +69,8 @@ Payment will be charged to your iTunes account and auto-renews unless disabled i
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tFh-9Q-oFf">
-                    <rect key="frame" x="439" y="278" width="47" height="32"/>
-                    <buttonCell key="cell" type="push" bezelStyle="rounded" image="NSRefreshTemplate" imagePosition="only" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="Azz-yr-SIz">
+                    <rect key="frame" x="450" y="278" width="36" height="32"/>
+                    <buttonCell key="cell" type="push" bezelStyle="rounded" imagePosition="only" alignment="center" borderStyle="border" transparent="YES" imageScaling="proportionallyDown" inset="2" id="Azz-yr-SIz">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                         <string key="keyEquivalent">R</string>
@@ -349,6 +349,5 @@ Payment will be charged to your iTunes account and auto-renews unless disabled i
     </objects>
     <resources>
         <image name="NSRefreshFreestandingTemplate" width="14" height="14"/>
-        <image name="NSRefreshTemplate" width="11" height="15"/>
     </resources>
 </document>


### PR DESCRIPTION
* Added missing `@escaping` to avoid crash.
* Removed image for a transparent button which started to appear either after building in Xcode 10 or when running on Mojave.

Refs #480