### PR TITLE
Read status directly from the first media

### DIFF
--- a/Telephone/AKSIPCall.m
+++ b/Telephone/AKSIPCall.m
@@ -152,7 +152,7 @@ const NSInteger kAKSIPCallsMax = 8;
     pjsua_call_info callInfo;
     pjsua_call_get_info((pjsua_call_id)[self identifier], &callInfo);
     
-    return (callInfo.media_status == PJSUA_CALL_MEDIA_LOCAL_HOLD) ? YES : NO;
+    return (callInfo.media[0].status == PJSUA_CALL_MEDIA_LOCAL_HOLD) ? YES : NO;
 }
 
 - (BOOL)isOnRemoteHold {
@@ -163,7 +163,7 @@ const NSInteger kAKSIPCallsMax = 8;
     pjsua_call_info callInfo;
     pjsua_call_get_info((pjsua_call_id)[self identifier], &callInfo);
     
-    return (callInfo.media_status == PJSUA_CALL_MEDIA_REMOTE_HOLD) ? YES : NO;
+    return (callInfo.media[0].status == PJSUA_CALL_MEDIA_REMOTE_HOLD) ? YES : NO;
 }
 
 
@@ -291,7 +291,7 @@ const NSInteger kAKSIPCallsMax = 8;
     pjsua_call_info callInfo;
     pjsua_call_get_info((pjsua_call_id)[self identifier], &callInfo);
     
-    pj_status_t status = pjsua_conf_disconnect(0, callInfo.conf_slot);
+    pj_status_t status = pjsua_conf_disconnect(0, callInfo.media[0].stream.aud.conf_slot);
     if (status == PJ_SUCCESS) {
         [self setMicrophoneMuted:YES];
     } else {
@@ -307,7 +307,7 @@ const NSInteger kAKSIPCallsMax = 8;
     pjsua_call_info callInfo;
     pjsua_call_get_info((pjsua_call_id)[self identifier], &callInfo);
     
-    pj_status_t status = pjsua_conf_connect(0, callInfo.conf_slot);
+    pj_status_t status = pjsua_conf_connect(0, callInfo.media[0].stream.aud.conf_slot);
     if (status == PJ_SUCCESS) {
         [self setMicrophoneMuted:NO];
     } else {

--- a/Telephone/PJSUAOnCallMediaState.m
+++ b/Telephone/PJSUAOnCallMediaState.m
@@ -55,7 +55,7 @@ static void CallMediaStateChanged(pjsua_call_info callInfo) {
     }
     ConnectCallToSoundDevice(call, &callInfo);
     [userAgent stopRingbackForCall:call];
-    PostMediaStateChangeNotification(call, callInfo.media_status);
+    PostMediaStateChangeNotification(call, callInfo.media[0].status);
 }
 
 static const char *MediaStatusTextWithStatus(pjsua_call_media_status status) {
@@ -64,11 +64,11 @@ static const char *MediaStatusTextWithStatus(pjsua_call_media_status status) {
 }
 
 static void ConnectCallToSoundDevice(AKSIPCall *call, const pjsua_call_info *callInfo) {
-    if (callInfo->media_status == PJSUA_CALL_MEDIA_ACTIVE ||
-        callInfo->media_status == PJSUA_CALL_MEDIA_REMOTE_HOLD) {
-        pjsua_conf_connect(callInfo->conf_slot, 0);
+    if (callInfo->media[0].status == PJSUA_CALL_MEDIA_ACTIVE ||
+        callInfo->media[0].status == PJSUA_CALL_MEDIA_REMOTE_HOLD) {
+        pjsua_conf_connect(callInfo->media[0].stream.aud.conf_slot, 0);
         if (!call.isMicrophoneMuted) {
-            pjsua_conf_connect(0, callInfo->conf_slot);
+            pjsua_conf_connect(0, callInfo->media[0].stream.aud.conf_slot);
         }
     }
 }

--- a/Telephone/PJSUAOnCallState.m
+++ b/Telephone/PJSUAOnCallState.m
@@ -68,7 +68,7 @@ void PJSUAOnCallState(pjsua_call_id callID, pjsip_event *event) {
         if (info.role == PJSIP_ROLE_UAC &&
             code == 180 &&
             msg->body == NULL &&
-            info.media_status == PJSUA_CALL_MEDIA_NONE) {
+            info.media[0].status == PJSUA_CALL_MEDIA_NONE) {
             mustStartRingback = YES;
         }
 


### PR DESCRIPTION
The PJSIP's pjsua_call_info.media_status should return the status of the first audio stream, but under certain circumstances it becomes unreliable. For example, when the other party returns 'a=inactive’ instead of the 'a=recvonly' for the call hold request.