### PR TITLE
Fix a crash when there are no enabled account controllers

### DIFF
--- a/Telephone/AccountsMenuItems.swift
+++ b/Telephone/AccountsMenuItems.swift
@@ -46,8 +46,8 @@ private extension AccountsMenuItems {
     }
 
     func updateItems() {
-        items = zip(controllers.enabled, 1...controllers.enabled.count).map {
-            NSMenuItem(controller: $0, target: self, selector: #selector(toggleAccountWindow), count: $1)
+        items = zip(controllers.enabled, controllers.enabled.indices).map {
+            NSMenuItem(controller: $0, target: self, selector: #selector(toggleAccountWindow), count: $1 + 1)
         }
         if !items.isEmpty {
             items.append(NSMenuItem.separator())


### PR DESCRIPTION
1...0 is not a valid range.

Refs #476 