### PR TITLE
Autorelease pool

### DIFF
--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -484,13 +484,17 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
 }
 
 - (void)thread_stopWithCompletion:(void (^ _Nonnull)(void))completion {
-    @autoreleasepool {
-        [self thread_stop];
-    }
+    [self thread_stop];
     dispatch_async(dispatch_get_main_queue(), completion);
 }
 
 - (void)thread_stop {
+    @autoreleasepool {
+        [self thread_stopInAutoreleasePool];
+    }
+}
+
+- (void)thread_stopInAutoreleasePool {
     if (self.ringbackPort && self.ringbackSlot != kAKSIPUserAgentInvalidIdentifier) {
         pjsua_conf_remove_port(self.ringbackSlot);
         self.ringbackSlot = kAKSIPUserAgentInvalidIdentifier;

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -263,6 +263,12 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
 }
 
 - (void)thread_startWithCompletion:(void (^ _Nonnull)(BOOL didStart))completion {
+    @autoreleasepool {
+        [self thread_startInAutoreleasePoolWithCompletion:completion];
+    }
+}
+
+- (void)thread_startInAutoreleasePoolWithCompletion:(void (^ _Nonnull)(BOOL didStart))completion {
     pj_status_t status;
 
     if (!pj_thread_is_registered()) {
@@ -478,7 +484,9 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
 }
 
 - (void)thread_stopWithCompletion:(void (^ _Nonnull)(void))completion {
-    [self thread_stop];
+    @autoreleasepool {
+        [self thread_stop];
+    }
     dispatch_async(dispatch_get_main_queue(), completion);
 }
 

--- a/Telephone/ThreadExecutionQueue.swift
+++ b/Telephone/ThreadExecutionQueue.swift
@@ -34,7 +34,7 @@ extension ThreadExecutionQueue: ExecutionQueue {
 
     @objc private func run(_ block: Any) {  // RunLoop.run() crashes if block type is () -> Void, so had to use Any instead.
         if let block = block as? () -> Void {
-            block()
+            autoreleasepool(invoking: block)
         }
     }
 }


### PR DESCRIPTION
The documentation on threads and runloops states that an autorelease pool is created automatically only on the main thread. It also happens in practice at least on macOS 10.10 and later. But because the documentation makes no guarantees, explicit autorelease pools should be created around calls on a long-living background thread.

Closes #500 