### PR TITLE
Enable DiffServ QoS

### DIFF
--- a/Telephone/AKSIPUserAgent.h
+++ b/Telephone/AKSIPUserAgent.h
@@ -130,6 +130,10 @@ extern const NSInteger kAKSIPUserAgentInvalidIdentifier;
 // Default: NO.
 @property(nonatomic, assign) BOOL usesICE;
 
+/// A Boolean value indicating if QoS is used.
+/// Default: YES.
+@property(nonatomic, assign) BOOL usesQoS;
+
 // Network port to use for SIP transport. Set 0 for any available port.
 // Default: 0.
 @property(nonatomic, assign) NSUInteger transportPort;

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -50,6 +50,7 @@ static const NSInteger kAKSIPUserAgentDefaultLogLevel = 3;
 static const NSInteger kAKSIPUserAgentDefaultConsoleLogLevel = 0;
 static const BOOL kAKSIPUserAgentDefaultDetectsVoiceActivity = YES;
 static const BOOL kAKSIPUserAgentDefaultUsesICE = NO;
+static const BOOL kAKSIPUserAgentDefaultUsesQoS = YES;
 static const NSInteger kAKSIPUserAgentDefaultTransportPort = 0;
 static const BOOL kAKSIPUserAgentDefaultUsesG711Only = NO;
 static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
@@ -229,6 +230,7 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     [self setConsoleLogLevel:kAKSIPUserAgentDefaultConsoleLogLevel];
     [self setDetectsVoiceActivity:kAKSIPUserAgentDefaultDetectsVoiceActivity];
     [self setUsesICE:kAKSIPUserAgentDefaultUsesICE];
+    [self setUsesQoS:kAKSIPUserAgentDefaultUsesQoS];
     [self setTransportPort:kAKSIPUserAgentDefaultTransportPort];
     [self setUsesG711Only:kAKSIPUserAgentDefaultUsesG711Only];
     [self setLocksCodec:kAKSIPUserAgentDefaultLocksCodec];
@@ -346,6 +348,12 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     mediaConfig.no_vad = ![self detectsVoiceActivity];
     mediaConfig.enable_ice = [self usesICE];
     mediaConfig.snd_auto_close_time = 1;
+
+    if (self.usesQoS) {
+        transportConfig.qos_params.flags = PJ_QOS_PARAM_HAS_DSCP;
+        transportConfig.qos_params.dscp_val = 24;
+    }
+
     transportConfig.port = (unsigned)[self transportPort];
 
     if ([[self transportPublicHost] length] > 0) {
@@ -545,6 +553,10 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     accountConfig.cred_info[0].data = [aPassword pjString];
     
     accountConfig.rtp_cfg.port = 4000;
+
+    if (self.usesQoS) {
+        accountConfig.rtp_cfg.qos_type = PJ_QOS_TYPE_VOICE;
+    }
     
     if ([[anAccount proxyHost] length] > 0) {
         accountConfig.proxy_cnt = 1;

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -98,6 +98,7 @@ NS_ASSUME_NONNULL_END
         defaultsDict[kSTUNServerPort] = @0;
         defaultsDict[kVoiceActivityDetection] = @NO;
         defaultsDict[kUseICE] = @NO;
+        defaultsDict[kUseQoS] = @YES;
         defaultsDict[kLogLevel] = @3;
         defaultsDict[kConsoleLogLevel] = @0;
         defaultsDict[kTransportPort] = @0;
@@ -614,6 +615,7 @@ NS_ASSUME_NONNULL_END
     [[self userAgent] setConsoleLogLevel:[defaults integerForKey:kConsoleLogLevel]];
     [[self userAgent] setDetectsVoiceActivity:[defaults boolForKey:kVoiceActivityDetection]];
     [[self userAgent] setUsesICE:[defaults boolForKey:kUseICE]];
+    [[self userAgent] setUsesQoS:[defaults boolForKey:kUseQoS]];
     [[self userAgent] setTransportPort:[defaults integerForKey:kTransportPort]];
     [[self userAgent] setTransportPublicHost:[defaults stringForKey:kTransportPublicHost]];
     [[self userAgent] setUsesG711Only:[defaults boolForKey:kUseG711Only]];

--- a/Telephone/UserDefaultsKeys.h
+++ b/Telephone/UserDefaultsKeys.h
@@ -35,6 +35,7 @@ extern NSString * const kOutboundProxyHost;
 extern NSString * const kOutboundProxyPort;
 extern NSString * const kUseICE;
 extern NSString * const kUseDNSSRV;
+extern NSString * const kUseQoS;
 extern NSString * const kSignificantPhoneNumberLength;
 extern NSString * const kAutoCloseCallWindow;
 extern NSString * const kAutoCloseMissedCallWindow;

--- a/Telephone/UserDefaultsKeys.m
+++ b/Telephone/UserDefaultsKeys.m
@@ -34,6 +34,7 @@ NSString * const kOutboundProxyHost = @"OutboundProxyHost";
 NSString * const kOutboundProxyPort = @"OutboundProxyPort";
 NSString * const kUseICE = @"UseICE";
 NSString * const kUseDNSSRV = @"UseDNSSRV";
+NSString * const kUseQoS = @"UseQoS";
 NSString * const kSignificantPhoneNumberLength = @"SignificantPhoneNumberLength";
 NSString * const kAutoCloseCallWindow = @"AutoCloseCallWindow";
 NSString * const kAutoCloseMissedCallWindow = @"AutoCloseMissedCallWindow";


### PR DESCRIPTION
DiffServ DSCP values are set in the IP packets transmitting SIP and RTP traffic.

SIP: DSCP 24 (CS3)
RTP: DSCP 46 (EF)

At the moment, this doesn’t seem to work on macOS 10.14 but works on macOS 10.10. Testing on the other supported macOS versions 10.11-10.13 is required.

Closes #510 