### PR TITLE
Call window title bar back to non-transparent

### DIFF
--- a/Telephone/Base.lproj/Call.xib
+++ b/Telephone/Base.lproj/Call.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Call" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" visibleAtLaunch="NO" frameAutosaveName="Call" animationBehavior="default" titlebarAppearsTransparent="YES" id="1">
+        <window title="Call" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" visibleAtLaunch="NO" frameAutosaveName="Call" animationBehavior="default" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" texturedBackground="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="417" width="300" height="91"/>


### PR DESCRIPTION
When a call transfer window sheet is presented and the title bar is transparent, the sheet obscures the title bar and hides the original caller's address.

#487 