### PR TITLE
Separate PJSIP memory pools

### DIFF
--- a/Telephone/AKSIPURI.m
+++ b/Telephone/AKSIPURI.m
@@ -99,7 +99,7 @@
     }
     
     pjsip_name_addr *nameAddr;
-    nameAddr = (pjsip_name_addr *)pjsip_parse_uri([[AKSIPUserAgent sharedUserAgent] pool],
+    nameAddr = (pjsip_name_addr *)pjsip_parse_uri([[AKSIPUserAgent sharedUserAgent] poolResettingIfNeeded],
                                                   (char *)[SIPURIString cStringUsingEncoding:NSUTF8StringEncoding],
                                                   [SIPURIString length], PJSIP_PARSE_URI_AS_NAMEADDR);
     if (nameAddr == NULL) {

--- a/Telephone/AKSIPUserAgent.h
+++ b/Telephone/AKSIPUserAgent.h
@@ -84,9 +84,6 @@ extern const NSInteger kAKSIPUserAgentInvalidIdentifier;
 // Receiver's call data.
 @property(nonatomic, readonly, assign) AKSIPUserAgentCallData *callData;
 
-// A pool used by the underlying PJSUA library of the receiver.
-@property(readonly, assign) pj_pool_t *pool;
-
 @property(nonatomic, assign) NSInteger maxCalls;
 
 // An array of DNS servers to use by the receiver. If set, DNS SRV will be
@@ -168,6 +165,8 @@ extern const NSInteger kAKSIPUserAgentInvalidIdentifier;
 // Stops user agent.
 - (void)stop;
 - (void)stopAndWait;
+
+- (pj_pool_t *)poolResettingIfNeeded;
 
 // Adds an account to the user agent.
 - (BOOL)addAccount:(AKSIPAccount *)anAccount withPassword:(NSString *)aPassword;


### PR DESCRIPTION
The memory pool that is needed for the ringback tones is now used only privately. The public memory pool that is used for URI parsing is now released when a certain threshold is reached.

Closes #515 