### PR TITLE
Call transfer sheet positioning

### DIFF
--- a/Telephone/Base.lproj/Call.xib
+++ b/Telephone/Base.lproj/Call.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Call" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" visibleAtLaunch="NO" frameAutosaveName="Call" animationBehavior="default" id="1">
+        <window title="Call" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" visibleAtLaunch="NO" frameAutosaveName="Call" animationBehavior="default" titlebarAppearsTransparent="YES" id="1">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" texturedBackground="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="417" width="300" height="91"/>

--- a/Telephone/CallController.m
+++ b/Telephone/CallController.m
@@ -449,6 +449,11 @@ static const NSTimeInterval kRedialButtonReenableTime = 1.0;
     [_endedCallViewController removeObservations];
 }
 
+- (NSRect)window:(NSWindow *)window willPositionSheet:(NSWindow *)sheet usingRect:(NSRect)rect {
+    rect.origin.y = [self.window contentRectForFrameRect:self.window.frame].size.height;
+    return rect;
+}
+
 
 #pragma mark -
 #pragma mark AKSIPCallDelegate


### PR DESCRIPTION
Set call window title bar again to transparent and calculate transfer sheet position manually, so that it would be presented the same way as when the title bar is non-transparent.

Issue #487 