### PR TITLE
PJSUA call info concurrent access

### DIFF
--- a/Telephone.xcodeproj/project.pbxproj
+++ b/Telephone.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		8A645FF11E12C8AD00515151 /* MatchedContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A645FEE1E12AA6300515151 /* MatchedContact.swift */; };
 		8A645FF51E12C98400515151 /* ContactCallHistoryRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A645FF41E12C98400515151 /* ContactCallHistoryRecord.swift */; };
 		8A645FF71E12CB7F00515151 /* ContactCallHistoryRecordGetAllUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A645FF61E12CB7F00515151 /* ContactCallHistoryRecordGetAllUseCase.swift */; };
+		8A6568912180641400DAF0F6 /* PJSUACallInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6568902180641400DAF0F6 /* PJSUACallInfo.m */; };
 		8A68C94C1FFE640B005125AF /* LogFileURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A68C94B1FFE640B005125AF /* LogFileURLTests.swift */; };
 		8A68C94E1FFE6453005125AF /* LogFileURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A68C94D1FFE6452005125AF /* LogFileURL.swift */; };
 		8A68C94F1FFE6453005125AF /* LogFileURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A68C94D1FFE6452005125AF /* LogFileURL.swift */; };
@@ -1090,6 +1091,8 @@
 		8A645FEE1E12AA6300515151 /* MatchedContact.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MatchedContact.swift; sourceTree = "<group>"; };
 		8A645FF41E12C98400515151 /* ContactCallHistoryRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactCallHistoryRecord.swift; sourceTree = "<group>"; };
 		8A645FF61E12CB7F00515151 /* ContactCallHistoryRecordGetAllUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactCallHistoryRecordGetAllUseCase.swift; sourceTree = "<group>"; };
+		8A65688F2180641400DAF0F6 /* PJSUACallInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PJSUACallInfo.h; sourceTree = "<group>"; };
+		8A6568902180641400DAF0F6 /* PJSUACallInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PJSUACallInfo.m; sourceTree = "<group>"; };
 		8A68C94B1FFE640B005125AF /* LogFileURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LogFileURLTests.swift; path = TelephoneTests/LogFileURLTests.swift; sourceTree = SOURCE_ROOT; };
 		8A68C94D1FFE6452005125AF /* LogFileURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFileURL.swift; sourceTree = "<group>"; };
 		8A68C9511FFE6A8C005125AF /* ApplicationDataLocationsFake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationDataLocationsFake.swift; sourceTree = "<group>"; };
@@ -3265,6 +3268,8 @@
 				AA0302F00EB9F347000738F7 /* AKSIPURI.h */,
 				AA0302F10EB9F347000738F7 /* AKSIPURI.m */,
 				8A9175941CA4841F00354E26 /* PJSUACallbacks.h */,
+				8A65688F2180641400DAF0F6 /* PJSUACallInfo.h */,
+				8A6568902180641400DAF0F6 /* PJSUACallInfo.m */,
 				8A9175981CA59D5C00354E26 /* PJSUAOnIncomingCall.m */,
 				8A91759B1CA59E2700354E26 /* PJSUAOnCallState.m */,
 				8A91759E1CA59F1100354E26 /* PJSUAOnCallMediaState.m */,
@@ -3942,6 +3947,7 @@
 				8A9175AB1CA5A92500354E26 /* PJSUAOnNATDetect.m in Sources */,
 				AAFCFFBD1074BFCA0018C7DA /* AccountSetupController.m in Sources */,
 				8AFC630E1D8C6F490022470D /* Array+Creating.swift in Sources */,
+				8A6568912180641400DAF0F6 /* PJSUACallInfo.m in Sources */,
 				AAD92132107A5E9F00F142A4 /* ActiveCallViewController.m in Sources */,
 				8AA748BC1D704962000587DC /* MusicPlayers.swift in Sources */,
 				8AB5A0C71D084DD300579CE8 /* DefaultStoreViewPresenter.swift in Sources */,

--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -23,6 +23,7 @@
 
 #import "AKSIPAccountDelegate.h"
 
+@class PJSUACallInfo;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -126,7 +127,7 @@ extern const NSInteger kAKSIPAccountDefaultReregistrationTime;
 // Makes a call to a given destination URI.
 - (void)makeCallTo:(AKSIPURI *)destination completion:(void (^)(AKSIPCall *))completion;
 
-- (AKSIPCall *)addCallWithInfo:(pjsua_call_info)info;
+- (AKSIPCall *)addCallWithInfo:(PJSUACallInfo *)info;
 - (nullable AKSIPCall *)callWithIdentifier:(NSInteger)identifier;
 - (void)removeCall:(AKSIPCall *)call;
 - (void)removeAllCalls;

--- a/Telephone/AKSIPCall.h
+++ b/Telephone/AKSIPCall.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, AKSIPCallState) {
     kAKSIPCallDisconnectedState = PJSIP_INV_STATE_DISCONNECTED
 };
 
-@class AKSIPAccount, AKSIPURI;
+@class AKSIPAccount, AKSIPURI, PJSUACallInfo;
 
 @interface AKSIPCall : NSObject <Call>
 
@@ -75,7 +75,7 @@ typedef NS_ENUM(NSUInteger, AKSIPCallState) {
 @property(nonatomic, readonly, getter=isOnLocalHold) BOOL onLocalHold;
 @property(nonatomic, readonly, getter=isOnRemoteHold) BOOL onRemoteHold;
 
-- (instancetype)initWithSIPAccount:(AKSIPAccount *)account info:(pjsua_call_info)info;
+- (instancetype)initWithSIPAccount:(AKSIPAccount *)account info:(PJSUACallInfo *)info;
 
 - (void)answer;
 - (void)hangUp;

--- a/Telephone/AKSIPCall.m
+++ b/Telephone/AKSIPCall.m
@@ -22,6 +22,7 @@
 #import "AKSIPAccount.h"
 #import "AKSIPURI.h"
 #import "AKSIPUserAgent.h"
+#import "PJSUACallInfo.h"
 
 #import "Telephone-Swift.h"
 
@@ -167,25 +168,25 @@
 
 #pragma mark -
 
-- (instancetype)initWithSIPAccount:(AKSIPAccount *)account info:(pjsua_call_info)info {
+- (instancetype)initWithSIPAccount:(AKSIPAccount *)account info:(PJSUACallInfo *)info {
     self = [super init];
     if (self == nil) {
         return nil;
     }
 
     _account = account;
-    _identifier = info.id;
+    _identifier = info.identifier;
 
     _date = [NSDate date];
 
-    _incoming = info.role == PJSIP_ROLE_UAS;
+    _incoming = info.isIncoming;
     _missed = _incoming;
-    _state = (AKSIPCallState)info.state;
-    _stateText = [NSString stringWithPJString:info.state_text];
-    _lastStatus = info.last_status;
-    _lastStatusText = [NSString stringWithPJString:info.last_status_text];
-    _localURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:info.local_info]];
-    _remoteURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:info.remote_info]];
+    _state = info.state;
+    _stateText = info.stateText;
+    _lastStatus = info.lastStatus;
+    _lastStatusText = info.lastStatusText;
+    _localURI = info.localURI;
+    _remoteURI = info.remoteURI;
     _remote = [[URI alloc] initWithURI:_remoteURI];
 
     return self;

--- a/Telephone/AKSIPURI.m
+++ b/Telephone/AKSIPURI.m
@@ -98,10 +98,12 @@
         return nil;
     }
     
-    pjsip_name_addr *nameAddr;
-    nameAddr = (pjsip_name_addr *)pjsip_parse_uri([[AKSIPUserAgent sharedUserAgent] poolResettingIfNeeded],
-                                                  (char *)[SIPURIString cStringUsingEncoding:NSUTF8StringEncoding],
-                                                  [SIPURIString length], PJSIP_PARSE_URI_AS_NAMEADDR);
+    pjsip_name_addr * __block nameAddr;
+    dispatch_sync(AKSIPUserAgent.sharedUserAgent.poolQueue, ^{
+        nameAddr = (pjsip_name_addr *)pjsip_parse_uri([[AKSIPUserAgent sharedUserAgent] poolResettingIfNeeded],
+                                                      (char *)[SIPURIString cStringUsingEncoding:NSUTF8StringEncoding],
+                                                      [SIPURIString length], PJSIP_PARSE_URI_AS_NAMEADDR);
+    });
     if (nameAddr == NULL) {
         return nil;
     }

--- a/Telephone/AKSIPUserAgent.h
+++ b/Telephone/AKSIPUserAgent.h
@@ -152,6 +152,7 @@ extern const NSInteger kAKSIPUserAgentInvalidIdentifier;
 /// Default: YES.
 @property(nonatomic, assign) BOOL locksCodec;
 
+@property(nonatomic, readonly) dispatch_queue_t poolQueue;
 
 // Returns the shared SIP user agent object.
 + (AKSIPUserAgent *)sharedUserAgent;

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -239,6 +239,8 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     
     [self setRingbackSlot:kAKSIPUserAgentInvalidIdentifier];
 
+    _poolQueue = dispatch_queue_create("com.tlphn.Telephone.AKSIPUserAgent.PJSIP.pool", DISPATCH_QUEUE_SERIAL);
+
     _thread = [[WaitingThread alloc] init];
     _thread.qualityOfService = NSQualityOfServiceUserInitiated;
     [_thread start];

--- a/Telephone/PJSUACallInfo.h
+++ b/Telephone/PJSUACallInfo.h
@@ -1,0 +1,44 @@
+//
+//  PJSUACallInfo.h
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+@import Foundation;
+
+#import <pjsua-lib/pjsua.h>
+
+#import "AKSIPCall.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PJSUACallInfo : NSObject
+
+@property(nonatomic, readonly) NSInteger identifier;
+@property(nonatomic, readonly) NSInteger accountIdentifier;
+@property(nonatomic, readonly) AKSIPCallState state;
+@property(nonatomic, readonly) NSString *stateText;
+@property(nonatomic, readonly) NSInteger lastStatus;
+@property(nonatomic, readonly) NSString *lastStatusText;
+@property(nonatomic, readonly) AKSIPURI *localURI;
+@property(nonatomic, readonly) AKSIPURI *remoteURI;
+@property(nonatomic, readonly, getter=isIncoming) BOOL incoming;
+
+- (instancetype)initWithInfo:(pjsua_call_info)info;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Telephone/PJSUACallInfo.m
+++ b/Telephone/PJSUACallInfo.m
@@ -1,0 +1,41 @@
+//
+//  PJSUACallInfo.m
+//  Telephone
+//
+//  Copyright © 2008-2016 Alexey Kuznetsov
+//  Copyright © 2016-2018 64 Characters
+//
+//  Telephone is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Telephone is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+
+#import "PJSUACallInfo.h"
+
+#import "AKNSString+PJSUA.h"
+#import "AKSIPURI.h"
+
+@implementation PJSUACallInfo
+
+- (instancetype)initWithInfo:(pjsua_call_info)info {
+    if ((self = [super init])) {
+        _identifier = info.id;
+        _accountIdentifier = info.acc_id;
+        _state = (AKSIPCallState)info.state;
+        _stateText = [NSString stringWithPJString:info.state_text];
+        _lastStatus = info.last_status;
+        _lastStatusText = [NSString stringWithPJString:info.last_status_text];
+        _localURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:info.local_info]];
+        _remoteURI = [AKSIPURI SIPURIWithString:[NSString stringWithPJString:info.remote_info]];
+        _incoming = info.role == PJSIP_ROLE_UAS;
+    }
+    return self;
+}
+
+@end

--- a/Telephone/PJSUAOnCallReplaced.m
+++ b/Telephone/PJSUAOnCallReplaced.m
@@ -21,6 +21,7 @@
 #import "AKSIPAccount.h"
 #import "AKSIPCall.h"
 #import "AKSIPUserAgent.h"
+#import "PJSUACallInfo.h"
 
 #define THIS_FILE "PJSUAOnCallReplaced.m"
 
@@ -33,11 +34,12 @@ void PJSUAOnCallReplaced(pjsua_call_id oldID, pjsua_call_id newID) {
                oldID, (int)oldInfo.remote_info.slen, oldInfo.remote_info.ptr,
                newID, (int)newInfo.remote_info.slen, newInfo.remote_info.ptr));
 
-    NSInteger accountIdentifier = newInfo.acc_id;
+    PJSUACallInfo *newInfoWrapper = [[PJSUACallInfo alloc] initWithInfo:newInfo];
+
     dispatch_async(dispatch_get_main_queue(), ^{
         PJ_LOG(3, (THIS_FILE, "Creating AKSIPCall for call %d from replaced callback", newID));
         AKSIPUserAgent *userAgent = [AKSIPUserAgent sharedUserAgent];
-        AKSIPAccount *account = [userAgent accountWithIdentifier:accountIdentifier];
-        [account addCallWithInfo:newInfo];
+        AKSIPAccount *account = [userAgent accountWithIdentifier:newInfoWrapper.accountIdentifier];
+        [account addCallWithInfo:newInfoWrapper];
     });
 }

--- a/Telephone/PJSUAOnIncomingCall.m
+++ b/Telephone/PJSUAOnIncomingCall.m
@@ -21,6 +21,7 @@
 #import "AKSIPAccount.h"
 #import "AKSIPCall.h"
 #import "AKSIPUserAgent.h"
+#import "PJSUACallInfo.h"
 
 #define THIS_FILE "PJSUAOnIncomingCall.m"
 
@@ -28,9 +29,10 @@ void PJSUAOnIncomingCall(pjsua_acc_id accountID, pjsua_call_id callID, pjsip_rx_
     PJ_LOG(3, (THIS_FILE, "Incoming call for account %d", accountID));
     pjsua_call_info info;
     pjsua_call_get_info(callID, &info);
+    PJSUACallInfo *infoWrapper = [[PJSUACallInfo alloc] initWithInfo:info];
     dispatch_async(dispatch_get_main_queue(), ^{
         AKSIPAccount *account = [[AKSIPUserAgent sharedUserAgent] accountWithIdentifier:accountID];
-        AKSIPCall *call = [account addCallWithInfo:info];
+        AKSIPCall *call = [account addCallWithInfo:infoWrapper];
         [account.delegate SIPAccount:account didReceiveCall:call];
         [[NSNotificationCenter defaultCenter] postNotificationName:AKSIPCallIncomingNotification object:call];
     });


### PR DESCRIPTION
Extract PJSUA call info and convert it to an Objective-C object before passing it between threads.

Closes #518 