### PR TITLE
Explicitly set DSCP value for RTP

### DIFF
--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -555,7 +555,8 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     accountConfig.rtp_cfg.port = 4000;
 
     if (self.usesQoS) {
-        accountConfig.rtp_cfg.qos_type = PJ_QOS_TYPE_VOICE;
+        accountConfig.rtp_cfg.qos_params.flags = PJ_QOS_PARAM_HAS_DSCP;
+        accountConfig.rtp_cfg.qos_params.dscp_val = 46;
     }
     
     if ([[anAccount proxyHost] length] > 0) {


### PR DESCRIPTION
Setting the QoS type to `PJ_QOS_TYPE_VOICE` results in the `0xc0` value of the ToS field, which is `0x30` or `48` value of DSCP. However, we want the value to be the standard `46`.

Issue #510 