### PR TITLE
Update IP address in SDP

### DIFF
--- a/Telephone/AKSIPAccount.h
+++ b/Telephone/AKSIPAccount.h
@@ -84,6 +84,11 @@ extern const NSInteger kAKSIPAccountDefaultReregistrationTime;
 /// address as the one in the REGISTER request.
 @property(nonatomic) BOOL updatesViaHeader;
 
+/// A Boolean value indicating if IP address in SDP should be automatically updated.
+///
+/// When YES, and when STUN and ICE are disabled, then the IP address found in registration response will be used.
+@property(nonatomic) BOOL updatesSDP;
+
 // The receiver's identifier at the user agent.
 @property(nonatomic, readonly) NSInteger identifier;
 

--- a/Telephone/AKSIPUserAgent.m
+++ b/Telephone/AKSIPUserAgent.m
@@ -596,6 +596,7 @@ static const BOOL kAKSIPUserAgentDefaultLocksCodec = YES;
     
     accountConfig.allow_contact_rewrite = anAccount.updatesContactHeader ? PJ_TRUE : PJ_FALSE;
     accountConfig.allow_via_rewrite = anAccount.updatesViaHeader ? PJ_TRUE : PJ_FALSE;
+    accountConfig.allow_sdp_nat_rewrite = anAccount.updatesSDP ? PJ_TRUE : PJ_FALSE;
 
     accountConfig.lock_codec = self.locksCodec ? PJ_TRUE : PJ_FALSE;
     

--- a/Telephone/AccountPreferencesViewController.h
+++ b/Telephone/AccountPreferencesViewController.h
@@ -42,6 +42,7 @@
 @property(nonatomic, weak) IBOutlet NSTextField *reregistrationTimeField;
 @property(nonatomic, weak) IBOutlet NSButton *substitutePlusCharacterCheckBox;
 @property(nonatomic, weak) IBOutlet NSTextField *plusCharacterSubstitutionField;
+@property(nonatomic, weak) IBOutlet NSTextField *plusCharacterSubstitutionLabel;
 @property(nonatomic, weak) IBOutlet NSButton *useProxyCheckBox;
 @property(nonatomic, weak) IBOutlet NSTextField *proxyHostField;
 @property(nonatomic, weak) IBOutlet NSTextField *proxyPortField;

--- a/Telephone/AccountPreferencesViewController.h
+++ b/Telephone/AccountPreferencesViewController.h
@@ -48,7 +48,7 @@
 @property(nonatomic, weak) IBOutlet NSTextField *SIPAddressField;
 @property(nonatomic, weak) IBOutlet NSTextField *registrarField;
 @property(nonatomic, weak) IBOutlet NSTextField *cantEditAccountLabel;
-@property(nonatomic, weak) IBOutlet NSButton *updateHeadersCheckBox;
+@property(nonatomic, weak) IBOutlet NSButton *updateIPAddressCheckBox;
 
 // Raises |Add Account| sheet.
 - (IBAction)showAddAccountSheet:(id)sender;

--- a/Telephone/AccountPreferencesViewController.m
+++ b/Telephone/AccountPreferencesViewController.m
@@ -188,7 +188,7 @@ static const NSUInteger kAccountsMax = 32;
             [[self SIPAddressField] setEnabled:NO];
             [[self registrarField] setEnabled:NO];
             [[self cantEditAccountLabel] setHidden:NO];
-            [[self updateHeadersCheckBox] setEnabled:NO];
+            [[self updateIPAddressCheckBox] setEnabled:NO];
             
         } else {
             [[self accountEnabledCheckBox] setState:NSOffState];
@@ -220,7 +220,7 @@ static const NSUInteger kAccountsMax = 32;
             [[self SIPAddressField] setEnabled:YES];
             [[self registrarField] setEnabled:YES];
             [[self cantEditAccountLabel] setHidden:YES];
-            [[self updateHeadersCheckBox] setEnabled:YES];
+            [[self updateIPAddressCheckBox] setEnabled:YES];
         }
         
         // Populate fields.
@@ -318,14 +318,14 @@ static const NSUInteger kAccountsMax = 32;
         
         // Update headers checkbox.
         if ([accountDict[kUpdateContactHeader] boolValue] && [accountDict[kUpdateViaHeader] boolValue] && [accountDict[kUpdateSDP] boolValue]) {
-            [[self updateHeadersCheckBox] setAllowsMixedState:NO];
-            [[self updateHeadersCheckBox] setState:NSOnState];
+            [[self updateIPAddressCheckBox] setAllowsMixedState:NO];
+            [[self updateIPAddressCheckBox] setState:NSOnState];
         } else if ([accountDict[kUpdateContactHeader] boolValue] || [accountDict[kUpdateViaHeader] boolValue] || [accountDict[kUpdateSDP] boolValue]) {
-            [[self updateHeadersCheckBox] setAllowsMixedState:YES];
-            [[self updateHeadersCheckBox] setState:NSMixedState];
+            [[self updateIPAddressCheckBox] setAllowsMixedState:YES];
+            [[self updateIPAddressCheckBox] setState:NSMixedState];
         } else {
-            [[self updateHeadersCheckBox] setAllowsMixedState:NO];
-            [[self updateHeadersCheckBox] setState:NSOffState];
+            [[self updateIPAddressCheckBox] setAllowsMixedState:NO];
+            [[self updateIPAddressCheckBox] setState:NSOffState];
         }
         
     } else {  // if (index >= 0)
@@ -344,7 +344,7 @@ static const NSUInteger kAccountsMax = 32;
         [[self proxyPortField] setStringValue:@""];
         [[self SIPAddressField] setStringValue:@""];
         [[self registrarField] setStringValue:@""];
-        [[self updateHeadersCheckBox] setState:NSOffState];
+        [[self updateIPAddressCheckBox] setState:NSOffState];
         
         [[self accountEnabledCheckBox] setEnabled:NO];
         [[self accountDescriptionField] setEnabled:NO];
@@ -363,7 +363,7 @@ static const NSUInteger kAccountsMax = 32;
         [[self registrarField] setEnabled:NO];
         [[self registrarField] setPlaceholderString:nil];
         [[self cantEditAccountLabel] setHidden:YES];
-        [[self updateHeadersCheckBox] setEnabled:NO];
+        [[self updateIPAddressCheckBox] setEnabled:NO];
     }
 }
 
@@ -446,11 +446,11 @@ static const NSUInteger kAccountsMax = 32;
         
         accountDict[kRegistrar] = registrar;
         
-        if (self.updateHeadersCheckBox.state == NSOnState) {
+        if (self.updateIPAddressCheckBox.state == NSOnState) {
             accountDict[kUpdateContactHeader] = @YES;
             accountDict[kUpdateViaHeader] = @YES;
             accountDict[kUpdateSDP] = @YES;
-        } else if (self.updateHeadersCheckBox.state == NSMixedState) {
+        } else if (self.updateIPAddressCheckBox.state == NSMixedState) {
             accountDict[kUpdateContactHeader] = @YES;
             accountDict[kUpdateViaHeader] = @YES;
             accountDict[kUpdateSDP] = @NO;
@@ -496,7 +496,7 @@ static const NSUInteger kAccountsMax = 32;
         [[self SIPAddressField] setEnabled:NO];
         [[self registrarField] setEnabled:NO];
         [[self cantEditAccountLabel] setHidden:NO];
-        [[self updateHeadersCheckBox] setEnabled:NO];
+        [[self updateIPAddressCheckBox] setEnabled:NO];
         
         // Mark accounts table as needing redisplay.
         [[self accountsTable] reloadData];
@@ -526,7 +526,7 @@ static const NSUInteger kAccountsMax = 32;
         [[self SIPAddressField] setEnabled:YES];
         [[self registrarField] setEnabled:YES];
         [[self cantEditAccountLabel] setHidden:YES];
-        [[self updateHeadersCheckBox] setEnabled:YES];
+        [[self updateIPAddressCheckBox] setEnabled:YES];
     }
     
     savedAccounts[index] = accountDict;

--- a/Telephone/AccountPreferencesViewController.m
+++ b/Telephone/AccountPreferencesViewController.m
@@ -317,9 +317,14 @@ static const NSUInteger kAccountsMax = 32;
         }
         
         // Update headers checkbox.
-        if ([accountDict[kUpdateContactHeader] boolValue] && [accountDict[kUpdateViaHeader] boolValue]) {
+        if ([accountDict[kUpdateContactHeader] boolValue] && [accountDict[kUpdateViaHeader] boolValue] && [accountDict[kUpdateSDP] boolValue]) {
+            [[self updateHeadersCheckBox] setAllowsMixedState:NO];
             [[self updateHeadersCheckBox] setState:NSOnState];
+        } else if ([accountDict[kUpdateContactHeader] boolValue] || [accountDict[kUpdateViaHeader] boolValue] || [accountDict[kUpdateSDP] boolValue]) {
+            [[self updateHeadersCheckBox] setAllowsMixedState:YES];
+            [[self updateHeadersCheckBox] setState:NSMixedState];
         } else {
+            [[self updateHeadersCheckBox] setAllowsMixedState:NO];
             [[self updateHeadersCheckBox] setState:NSOffState];
         }
         
@@ -444,9 +449,15 @@ static const NSUInteger kAccountsMax = 32;
         if (self.updateHeadersCheckBox.state == NSOnState) {
             accountDict[kUpdateContactHeader] = @YES;
             accountDict[kUpdateViaHeader] = @YES;
+            accountDict[kUpdateSDP] = @YES;
+        } else if (self.updateHeadersCheckBox.state == NSMixedState) {
+            accountDict[kUpdateContactHeader] = @YES;
+            accountDict[kUpdateViaHeader] = @YES;
+            accountDict[kUpdateSDP] = @NO;
         } else {
             accountDict[kUpdateContactHeader] = @NO;
             accountDict[kUpdateViaHeader] = @NO;
+            accountDict[kUpdateSDP] = @NO;
         }
         
         // Set placeholders.

--- a/Telephone/AccountPreferencesViewController.m
+++ b/Telephone/AccountPreferencesViewController.m
@@ -181,6 +181,7 @@ static const NSUInteger kAccountsMax = 32;
             [[self substitutePlusCharacterCheckBox] setEnabled:NO];
             [[self substitutePlusCharacterCheckBox] setState:[accountDict[kSubstitutePlusCharacter] integerValue]];
             [[self plusCharacterSubstitutionField] setEnabled:NO];
+            [[self plusCharacterSubstitutionLabel] setTextColor:[NSColor disabledControlTextColor]];
             [[self useProxyCheckBox] setState:[accountDict[kUseProxy] integerValue]];
             [[self useProxyCheckBox] setEnabled:NO];
             [[self proxyHostField] setEnabled:NO];
@@ -206,6 +207,7 @@ static const NSUInteger kAccountsMax = 32;
             } else {
                 [[self plusCharacterSubstitutionField] setEnabled:NO];
             }
+            [[self plusCharacterSubstitutionLabel] setTextColor:[NSColor controlTextColor]];
             
             [[self useProxyCheckBox] setEnabled:YES];
             [[self useProxyCheckBox] setState:[accountDict[kUseProxy] integerValue]];
@@ -355,6 +357,7 @@ static const NSUInteger kAccountsMax = 32;
         [[self reregistrationTimeField] setEnabled:NO];
         [[self substitutePlusCharacterCheckBox] setEnabled:NO];
         [[self plusCharacterSubstitutionField] setEnabled:NO];
+        [[self plusCharacterSubstitutionLabel] setTextColor:[NSColor disabledControlTextColor]];
         [[self useProxyCheckBox] setEnabled:NO];
         [[self proxyHostField] setEnabled:NO];
         [[self proxyPortField] setEnabled:NO];
@@ -490,6 +493,7 @@ static const NSUInteger kAccountsMax = 32;
         [[self reregistrationTimeField] setEnabled:NO];
         [[self substitutePlusCharacterCheckBox] setEnabled:NO];
         [[self plusCharacterSubstitutionField] setEnabled:NO];
+        [[self plusCharacterSubstitutionLabel] setTextColor:[NSColor disabledControlTextColor]];
         [[self useProxyCheckBox] setEnabled:NO];
         [[self proxyHostField] setEnabled:NO];
         [[self proxyPortField] setEnabled:NO];
@@ -515,6 +519,7 @@ static const NSUInteger kAccountsMax = 32;
         if ([[self substitutePlusCharacterCheckBox] state] == NSOnState) {
             [[self plusCharacterSubstitutionField] setEnabled:YES];
         }
+        [[self plusCharacterSubstitutionLabel] setTextColor:[NSColor controlTextColor]];
         
         [[self useProxyCheckBox] setEnabled:YES];
         [[self useProxyCheckBox] setState:[accountDict[kUseProxy] integerValue]];

--- a/Telephone/AppController.m
+++ b/Telephone/AppController.m
@@ -391,6 +391,7 @@ NS_ASSUME_NONNULL_END
         }
         account.updatesContactHeader = [accountDict[kUpdateContactHeader] boolValue];
         account.updatesViaHeader = [accountDict[kUpdateViaHeader] boolValue];
+        account.updatesSDP = [accountDict[kUpdateSDP] boolValue];
 
         NSString *description = accountDict[kDescription];
         if ([description length] == 0) {
@@ -681,6 +682,7 @@ NS_ASSUME_NONNULL_END
         }
         account.updatesContactHeader = [accountDict[kUpdateContactHeader] boolValue];
         account.updatesViaHeader = [accountDict[kUpdateViaHeader] boolValue];
+        account.updatesSDP = [accountDict[kUpdateSDP] boolValue];
 
         NSString *description = accountDict[kDescription];
         if ([description length] == 0) {

--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -23,7 +23,7 @@
                 <outlet property="registrarField" destination="97" id="513"/>
                 <outlet property="reregistrationTimeField" destination="499" id="516"/>
                 <outlet property="substitutePlusCharacterCheckBox" destination="416" id="422"/>
-                <outlet property="updateHeadersCheckBox" destination="Dxg-la-6Uh" id="LFy-pw-QbK"/>
+                <outlet property="updateIPAddressCheckBox" destination="Dxg-la-6Uh" id="LFy-pw-QbK"/>
                 <outlet property="useProxyCheckBox" destination="424" id="434"/>
                 <outlet property="usernameField" destination="98" id="514"/>
                 <outlet property="view" destination="148" id="547"/>

--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -32,16 +32,16 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="148" userLabel="Accounts">
-            <rect key="frame" x="0.0" y="0.0" width="508" height="327"/>
+            <rect key="frame" x="0.0" y="0.0" width="508" height="359"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="79" userLabel="Table">
-                    <rect key="frame" x="20" y="49" width="130" height="264"/>
+                    <rect key="frame" x="20" y="49" width="130" height="296"/>
                     <clipView key="contentView" id="1uL-Un-sZt">
-                        <rect key="frame" x="1" y="0.0" width="128" height="263"/>
+                        <rect key="frame" x="1" y="0.0" width="128" height="295"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="83" id="82">
-                                <rect key="frame" x="0.0" y="0.0" width="128" height="240"/>
+                                <rect key="frame" x="0.0" y="0.0" width="128" height="272"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -86,15 +86,15 @@
                     </tableHeaderView>
                 </scrollView>
                 <tabView controlSize="small" initialItem="410" translatesAutoresizingMaskIntoConstraints="NO" id="409" userLabel="Tab View">
-                    <rect key="frame" x="157" y="39" width="338" height="277"/>
+                    <rect key="frame" x="157" y="39" width="338" height="309"/>
                     <tabViewItems>
                         <tabViewItem label="Account Information" identifier="1" id="410">
                             <view key="view" id="413" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="318" height="239"/>
+                                <rect key="frame" x="10" y="25" width="318" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="205" width="111" height="18"/>
+                                        <rect key="frame" x="14" y="226" width="111" height="18"/>
                                         <buttonCell key="cell" type="check" title="Use this account" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="108" y="125" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="135" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="108" y="67" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="77" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="43" y="128" width="60" height="14"/>
+                                        <rect key="frame" x="43" y="138" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Full Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="37" y="70" width="66" height="14"/>
+                                        <rect key="frame" x="37" y="80" width="66" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="User Name:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="45" y="41" width="58" height="14"/>
+                                        <rect key="frame" x="45" y="51" width="58" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="108" y="38" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="48" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="528">
-                                        <rect key="frame" x="108" y="96" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="106" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="529">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="530">
-                                        <rect key="frame" x="56" y="99" width="47" height="14"/>
+                                        <rect key="frame" x="56" y="109" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="531">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="534">
-                                        <rect key="frame" x="108" y="164" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="174" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="0P5-QA-beZ"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="536">
-                                        <rect key="frame" x="35" y="167" width="68" height="14"/>
+                                        <rect key="frame" x="35" y="177" width="68" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Description:" id="537">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -216,7 +216,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="530" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="0zA-ra-Hpb"/>
-                                    <constraint firstItem="534" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="25" id="1C0-TX-VdZ"/>
+                                    <constraint firstItem="534" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="36" id="1C0-TX-VdZ"/>
                                     <constraint firstItem="104" firstAttribute="baseline" secondItem="103" secondAttribute="baseline" id="44B-8S-6lE"/>
                                     <constraint firstItem="102" firstAttribute="trailing" secondItem="103" secondAttribute="trailing" id="83K-yj-YHs"/>
                                     <constraint firstItem="93" firstAttribute="leading" secondItem="413" secondAttribute="leading" constant="17" id="8in-eP-WoJ"/>
@@ -244,7 +244,7 @@
                                     <constraint firstItem="95" firstAttribute="top" secondItem="534" secondAttribute="bottom" constant="20" id="lQa-aA-v6D"/>
                                     <constraint firstItem="528" firstAttribute="baseline" secondItem="530" secondAttribute="baseline" id="lVJ-cB-X5V"/>
                                     <constraint firstItem="98" firstAttribute="top" secondItem="528" secondAttribute="bottom" constant="10" id="qOe-cA-aI0"/>
-                                    <constraint firstItem="93" firstAttribute="top" secondItem="413" secondAttribute="top" constant="19" id="rvX-9Z-2g6"/>
+                                    <constraint firstItem="93" firstAttribute="top" secondItem="413" secondAttribute="top" constant="30" id="rvX-9Z-2g6"/>
                                     <constraint firstItem="104" firstAttribute="top" secondItem="98" secondAttribute="bottom" constant="10" id="scl-ka-DzA"/>
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="528" secondAttribute="leading" id="uVp-M4-l1D"/>
                                 </constraints>
@@ -252,11 +252,11 @@
                         </tabViewItem>
                         <tabViewItem label="Advanced" identifier="2" id="411">
                             <view key="view" id="412" userLabel="Advanced">
-                                <rect key="frame" x="10" y="25" width="318" height="239"/>
+                                <rect key="frame" x="10" y="25" width="318" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="416">
-                                        <rect key="frame" x="32" y="207" width="85" height="18"/>
+                                        <rect key="frame" x="32" y="239" width="85" height="18"/>
                                         <buttonCell key="cell" type="check" title="Substitute “" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="417">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -266,7 +266,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="418">
-                                        <rect key="frame" x="115" y="206" width="29" height="19"/>
+                                        <rect key="frame" x="115" y="238" width="29" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="29" id="36G-Cq-aWp"/>
                                         </constraints>
@@ -283,7 +283,7 @@
                                         </connections>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="424">
-                                        <rect key="frame" x="32" y="92" width="130" height="18"/>
+                                        <rect key="frame" x="32" y="116" width="130" height="18"/>
                                         <buttonCell key="cell" type="check" title="Connect using proxy" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="425">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -293,7 +293,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="426">
-                                        <rect key="frame" x="115" y="68" width="185" height="19"/>
+                                        <rect key="frame" x="115" y="92" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="427">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -307,7 +307,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="428">
-                                        <rect key="frame" x="115" y="41" width="43" height="19"/>
+                                        <rect key="frame" x="115" y="65" width="43" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="43" id="aEq-0d-L66"/>
                                         </constraints>
@@ -324,7 +324,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="430">
-                                        <rect key="frame" x="68" y="71" width="42" height="14"/>
+                                        <rect key="frame" x="68" y="95" width="42" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Server:" id="431">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -332,7 +332,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="432">
-                                        <rect key="frame" x="80" y="44" width="30" height="14"/>
+                                        <rect key="frame" x="80" y="68" width="30" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Port:" id="433">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -340,7 +340,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="497">
-                                        <rect key="frame" x="17" y="180" width="93" height="14"/>
+                                        <rect key="frame" x="17" y="212" width="93" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Reregister every:" id="498">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -348,7 +348,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="499">
-                                        <rect key="frame" x="115" y="177" width="36" height="19"/>
+                                        <rect key="frame" x="115" y="209" width="36" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="36" id="nLU-0K-zla"/>
                                         </constraints>
@@ -362,7 +362,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="501">
-                                        <rect key="frame" x="152" y="180" width="49" height="14"/>
+                                        <rect key="frame" x="152" y="212" width="49" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="seconds" id="502">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -370,7 +370,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="96">
-                                        <rect key="frame" x="115" y="148" width="185" height="19"/>
+                                        <rect key="frame" x="115" y="180" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="113">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -384,7 +384,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="97">
-                                        <rect key="frame" x="115" y="119" width="185" height="19"/>
+                                        <rect key="frame" x="115" y="151" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="112">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -398,7 +398,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                                        <rect key="frame" x="39" y="151" width="71" height="14"/>
+                                        <rect key="frame" x="39" y="183" width="71" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="SIP Address:" id="109">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -406,7 +406,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101">
-                                        <rect key="frame" x="22" y="122" width="88" height="14"/>
+                                        <rect key="frame" x="22" y="154" width="88" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Registry Server:" id="108">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -414,18 +414,26 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Dxg-la-6Uh">
-                                        <rect key="frame" x="32" y="14" width="119" height="18"/>
+                                        <rect key="frame" x="32" y="30" width="119" height="18"/>
                                         <buttonCell key="cell" type="check" title="Update IP address" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="cPc-9z-FgQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
                                     </button>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ERB-3b-3jA">
-                                        <rect key="frame" x="142" y="209" width="49" height="14"/>
+                                        <rect key="frame" x="142" y="241" width="49" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="” for “+”" id="CHy-bC-ic4">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="npI-ab-hgu">
+                                        <rect key="frame" x="51" y="14" width="238" height="11"/>
+                                        <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" title="Enabling this option may solve some audio problems." id="NQK-9l-qkH">
+                                            <font key="font" metaFont="miniSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                 </subviews>
@@ -434,6 +442,7 @@
                                     <constraint firstItem="499" firstAttribute="top" secondItem="418" secondAttribute="bottom" constant="10" id="0Pl-Zw-7Ev"/>
                                     <constraint firstItem="418" firstAttribute="leading" secondItem="416" secondAttribute="trailing" id="4Tg-Wa-cia"/>
                                     <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="4mW-34-Ub8"/>
+                                    <constraint firstItem="npI-ab-hgu" firstAttribute="leading" secondItem="Dxg-la-6Uh" secondAttribute="leading" constant="18" id="AXc-Lv-BVc"/>
                                     <constraint firstItem="97" firstAttribute="trailing" secondItem="426" secondAttribute="trailing" id="Ava-h6-BiN"/>
                                     <constraint firstItem="ERB-3b-3jA" firstAttribute="baseline" secondItem="418" secondAttribute="baseline" id="Bws-00-BCL"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="18" id="CbD-vu-2pv"/>
@@ -443,6 +452,7 @@
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="I0z-8G-6f0"/>
                                     <constraint firstItem="497" firstAttribute="baseline" secondItem="499" secondAttribute="baseline" id="J73-ry-Wam"/>
                                     <constraint firstItem="432" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="JMu-tY-EdE"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="npI-ab-hgu" secondAttribute="trailing" constant="20" symbolic="YES" id="JTB-cf-LHc"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="428" secondAttribute="trailing" constant="20" symbolic="YES" id="JgT-Fn-RWY"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="499" secondAttribute="bottom" constant="10" id="KjC-p2-9ji"/>
                                     <constraint firstItem="499" firstAttribute="leading" secondItem="497" secondAttribute="trailing" constant="7" id="NE6-BV-leQ"/>
@@ -455,14 +465,16 @@
                                     <constraint firstItem="101" firstAttribute="baseline" secondItem="97" secondAttribute="baseline" id="ZEV-Of-3eP"/>
                                     <constraint firstItem="101" firstAttribute="trailing" secondItem="430" secondAttribute="trailing" id="ZFv-zu-tdf"/>
                                     <constraint firstItem="97" firstAttribute="leading" secondItem="426" secondAttribute="leading" id="ZYK-xu-ZaX"/>
+                                    <constraint firstAttribute="bottom" secondItem="npI-ab-hgu" secondAttribute="bottom" constant="14" id="a9Y-ya-KZm"/>
                                     <constraint firstItem="497" firstAttribute="baseline" secondItem="501" secondAttribute="baseline" id="b95-3g-uOj"/>
                                     <constraint firstItem="418" firstAttribute="top" secondItem="412" secondAttribute="top" constant="14" id="beP-Nm-QTW"/>
                                     <constraint firstItem="418" firstAttribute="baseline" secondItem="416" secondAttribute="baseline" id="e1f-0e-Vv3"/>
                                     <constraint firstItem="426" firstAttribute="leading" secondItem="428" secondAttribute="leading" id="fUe-Ez-cVT"/>
-                                    <constraint firstItem="Dxg-la-6Uh" firstAttribute="top" secondItem="428" secondAttribute="bottom" constant="12" id="hAX-ih-3IH"/>
+                                    <constraint firstItem="Dxg-la-6Uh" firstAttribute="top" secondItem="428" secondAttribute="bottom" constant="20" id="hAX-ih-3IH"/>
                                     <constraint firstItem="501" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="499" secondAttribute="trailing" constant="3" id="hGQ-If-5fh"/>
                                     <constraint firstItem="ERB-3b-3jA" firstAttribute="leading" secondItem="418" secondAttribute="trailing" id="hNh-Ab-Dl7"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ERB-3b-3jA" secondAttribute="trailing" constant="20" symbolic="YES" id="hTE-qI-LXB"/>
+                                    <constraint firstItem="npI-ab-hgu" firstAttribute="top" secondItem="Dxg-la-6Uh" secondAttribute="bottom" constant="8" id="lmg-JN-ryd"/>
                                     <constraint firstItem="430" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="qm7-5p-aU3"/>
                                     <constraint firstItem="430" firstAttribute="baseline" secondItem="426" secondAttribute="baseline" id="qv6-2z-t92"/>
                                     <constraint firstItem="426" firstAttribute="top" secondItem="424" secondAttribute="bottom" constant="8" symbolic="YES" id="rqK-zR-qP5"/>
@@ -474,7 +486,7 @@
                                     <constraint firstItem="430" firstAttribute="trailing" secondItem="432" secondAttribute="trailing" id="yHl-vv-axx"/>
                                     <constraint firstAttribute="trailing" secondItem="501" secondAttribute="trailing" priority="750" constant="119" id="yXf-AO-bIv"/>
                                     <constraint firstItem="424" firstAttribute="leading" secondItem="Dxg-la-6Uh" secondAttribute="leading" id="zTG-mC-AbM"/>
-                                    <constraint firstItem="424" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="12" id="zbu-gn-iIv"/>
+                                    <constraint firstItem="424" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="20" id="zbu-gn-iIv"/>
                                     <constraint firstItem="416" firstAttribute="leading" secondItem="424" secondAttribute="leading" id="zl4-nr-9jU"/>
                                     <constraint firstItem="101" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="zox-FM-NJq"/>
                                 </constraints>

--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -90,12 +90,12 @@
                     <tabViewItems>
                         <tabViewItem label="Account Information" identifier="1" id="410">
                             <view key="view" id="413" userLabel="Account Information">
-                                <rect key="frame" x="10" y="29" width="318" height="235"/>
+                                <rect key="frame" x="10" y="25" width="318" height="239"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="201" width="111" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Use this account" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" state="on" inset="2" id="94">
+                                        <rect key="frame" x="14" y="205" width="111" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Use this account" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="108" y="121" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="125" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="108" y="63" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="67" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="43" y="124" width="60" height="14"/>
+                                        <rect key="frame" x="43" y="128" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Full Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="37" y="66" width="66" height="14"/>
+                                        <rect key="frame" x="37" y="70" width="66" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="User Name:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="45" y="37" width="58" height="14"/>
+                                        <rect key="frame" x="45" y="41" width="58" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="108" y="34" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="38" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="528">
-                                        <rect key="frame" x="108" y="92" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="96" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="529">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="530">
-                                        <rect key="frame" x="56" y="95" width="47" height="14"/>
+                                        <rect key="frame" x="56" y="99" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="531">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="534">
-                                        <rect key="frame" x="108" y="160" width="185" height="19"/>
+                                        <rect key="frame" x="108" y="164" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="0P5-QA-beZ"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="536">
-                                        <rect key="frame" x="35" y="163" width="68" height="14"/>
+                                        <rect key="frame" x="35" y="167" width="68" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Description:" id="537">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -225,8 +225,12 @@
                                     <constraint firstItem="98" firstAttribute="baseline" secondItem="102" secondAttribute="baseline" id="F03-ck-yje"/>
                                     <constraint firstItem="528" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="GtG-ZP-Jdj"/>
                                     <constraint firstItem="536" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="KRK-Ac-tk7"/>
+                                    <constraint firstItem="536" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="Lkb-YC-DQ2"/>
+                                    <constraint firstItem="99" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="MMv-Ew-G2K"/>
                                     <constraint firstItem="98" firstAttribute="trailing" secondItem="104" secondAttribute="trailing" id="Ma2-r9-NgI"/>
                                     <constraint firstItem="528" firstAttribute="top" secondItem="95" secondAttribute="bottom" constant="10" id="OEP-3x-aSB"/>
+                                    <constraint firstItem="103" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="Rs6-0J-VPE"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="UDC-r0-F21"/>
                                     <constraint firstAttribute="trailing" secondItem="534" secondAttribute="trailing" constant="25" id="WAf-X4-LdX"/>
                                     <constraint firstItem="534" firstAttribute="leading" secondItem="536" secondAttribute="trailing" constant="7" id="ajg-yi-dBJ"/>
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="av8-w1-KMb"/>
@@ -234,6 +238,8 @@
                                     <constraint firstItem="528" firstAttribute="trailing" secondItem="98" secondAttribute="trailing" id="dHa-J4-8XH"/>
                                     <constraint firstItem="534" firstAttribute="trailing" secondItem="95" secondAttribute="trailing" id="ePv-sQ-PmP"/>
                                     <constraint firstItem="534" firstAttribute="leading" secondItem="95" secondAttribute="leading" id="fWo-cu-0xd"/>
+                                    <constraint firstItem="102" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="hJR-zT-mUc"/>
+                                    <constraint firstItem="530" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="hoG-Aa-SnS"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="528" secondAttribute="trailing" id="kmb-5M-JuA"/>
                                     <constraint firstItem="95" firstAttribute="top" secondItem="534" secondAttribute="bottom" constant="20" id="lQa-aA-v6D"/>
                                     <constraint firstItem="528" firstAttribute="baseline" secondItem="530" secondAttribute="baseline" id="lVJ-cB-X5V"/>
@@ -251,7 +257,7 @@
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="416">
                                         <rect key="frame" x="32" y="207" width="85" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Substitute “" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="417">
+                                        <buttonCell key="cell" type="check" title="Substitute “" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="417">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -278,7 +284,7 @@
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="424">
                                         <rect key="frame" x="32" y="92" width="130" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Connect using proxy" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="425">
+                                        <buttonCell key="cell" type="check" title="Connect using proxy" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="425">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -303,7 +309,7 @@
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="428">
                                         <rect key="frame" x="115" y="41" width="43" height="19"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="43" id="aEq-0d-L66"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="43" id="aEq-0d-L66"/>
                                         </constraints>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="5060" drawsBackground="YES" id="429">
                                             <font key="font" metaFont="smallSystem"/>
@@ -344,7 +350,7 @@
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="499">
                                         <rect key="frame" x="115" y="177" width="36" height="19"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="36" id="nLU-0K-zla"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="36" id="nLU-0K-zla"/>
                                         </constraints>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="300" drawsBackground="YES" id="500">
                                             <font key="font" metaFont="smallSystem"/>
@@ -427,14 +433,21 @@
                                     <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="05d-gK-lgS"/>
                                     <constraint firstItem="499" firstAttribute="top" secondItem="418" secondAttribute="bottom" constant="10" id="0Pl-Zw-7Ev"/>
                                     <constraint firstItem="418" firstAttribute="leading" secondItem="416" secondAttribute="trailing" id="4Tg-Wa-cia"/>
+                                    <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="4mW-34-Ub8"/>
                                     <constraint firstItem="97" firstAttribute="trailing" secondItem="426" secondAttribute="trailing" id="Ava-h6-BiN"/>
                                     <constraint firstItem="ERB-3b-3jA" firstAttribute="baseline" secondItem="418" secondAttribute="baseline" id="Bws-00-BCL"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="18" id="CbD-vu-2pv"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="97" secondAttribute="leading" id="DKL-g2-ELY"/>
+                                    <constraint firstAttribute="trailing" secondItem="428" secondAttribute="trailing" priority="750" constant="160" id="EVo-sc-C1F"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="501" secondAttribute="trailing" constant="20" symbolic="YES" id="H6r-la-wDh"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="I0z-8G-6f0"/>
                                     <constraint firstItem="497" firstAttribute="baseline" secondItem="499" secondAttribute="baseline" id="J73-ry-Wam"/>
+                                    <constraint firstItem="432" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="JMu-tY-EdE"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="428" secondAttribute="trailing" constant="20" symbolic="YES" id="JgT-Fn-RWY"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="499" secondAttribute="bottom" constant="10" id="KjC-p2-9ji"/>
                                     <constraint firstItem="499" firstAttribute="leading" secondItem="497" secondAttribute="trailing" constant="7" id="NE6-BV-leQ"/>
+                                    <constraint firstItem="497" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="19" id="NVO-ft-eEw"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Dxg-la-6Uh" secondAttribute="trailing" constant="20" symbolic="YES" id="Ndc-Js-HBq"/>
                                     <constraint firstItem="499" firstAttribute="leading" secondItem="96" secondAttribute="leading" id="P9e-Xc-JBy"/>
                                     <constraint firstItem="499" firstAttribute="leading" secondItem="412" secondAttribute="leading" constant="115" id="Qcx-L6-KTr"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" id="SaI-ao-4Gp"/>
@@ -447,18 +460,23 @@
                                     <constraint firstItem="418" firstAttribute="baseline" secondItem="416" secondAttribute="baseline" id="e1f-0e-Vv3"/>
                                     <constraint firstItem="426" firstAttribute="leading" secondItem="428" secondAttribute="leading" id="fUe-Ez-cVT"/>
                                     <constraint firstItem="Dxg-la-6Uh" firstAttribute="top" secondItem="428" secondAttribute="bottom" constant="12" id="hAX-ih-3IH"/>
-                                    <constraint firstItem="501" firstAttribute="leading" secondItem="499" secondAttribute="trailing" constant="3" id="hGQ-If-5fh"/>
+                                    <constraint firstItem="501" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="499" secondAttribute="trailing" constant="3" id="hGQ-If-5fh"/>
                                     <constraint firstItem="ERB-3b-3jA" firstAttribute="leading" secondItem="418" secondAttribute="trailing" id="hNh-Ab-Dl7"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ERB-3b-3jA" secondAttribute="trailing" constant="20" symbolic="YES" id="hTE-qI-LXB"/>
+                                    <constraint firstItem="430" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="qm7-5p-aU3"/>
                                     <constraint firstItem="430" firstAttribute="baseline" secondItem="426" secondAttribute="baseline" id="qv6-2z-t92"/>
                                     <constraint firstItem="426" firstAttribute="top" secondItem="424" secondAttribute="bottom" constant="8" symbolic="YES" id="rqK-zR-qP5"/>
                                     <constraint firstItem="432" firstAttribute="baseline" secondItem="428" secondAttribute="baseline" id="tuK-uA-EGB"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="424" secondAttribute="trailing" constant="20" symbolic="YES" id="ul4-4A-uYk"/>
                                     <constraint firstItem="96" firstAttribute="trailing" secondItem="97" secondAttribute="trailing" id="v32-ho-csZ"/>
                                     <constraint firstItem="428" firstAttribute="top" secondItem="426" secondAttribute="bottom" constant="8" symbolic="YES" id="vHr-be-BXc"/>
                                     <constraint firstItem="497" firstAttribute="trailing" secondItem="100" secondAttribute="trailing" id="y0k-rn-t5N"/>
                                     <constraint firstItem="430" firstAttribute="trailing" secondItem="432" secondAttribute="trailing" id="yHl-vv-axx"/>
+                                    <constraint firstAttribute="trailing" secondItem="501" secondAttribute="trailing" priority="750" constant="119" id="yXf-AO-bIv"/>
                                     <constraint firstItem="424" firstAttribute="leading" secondItem="Dxg-la-6Uh" secondAttribute="leading" id="zTG-mC-AbM"/>
                                     <constraint firstItem="424" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="12" id="zbu-gn-iIv"/>
                                     <constraint firstItem="416" firstAttribute="leading" secondItem="424" secondAttribute="leading" id="zl4-nr-9jU"/>
+                                    <constraint firstItem="101" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="zox-FM-NJq"/>
                                 </constraints>
                             </view>
                         </tabViewItem>
@@ -468,7 +486,7 @@
                     <rect key="frame" x="20" y="19" width="23" height="23"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="21" id="DT6-Ue-zlU"/>
-                        <constraint firstAttribute="width" constant="23" id="GUZ-fg-6gZ"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="23" id="GUZ-fg-6gZ"/>
                     </constraints>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="119">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -489,8 +507,8 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="548" userLabel="Cant Edit Account">
-                    <rect key="frame" x="171" y="23" width="311" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="You can’t change account settings when account is in use." id="549">
+                    <rect key="frame" x="162" y="23" width="328" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="You can’t change account settings when account is in use." id="549">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -498,6 +516,7 @@
                 </textField>
             </subviews>
             <constraints>
+                <constraint firstItem="548" firstAttribute="leading" secondItem="409" secondAttribute="leading" id="8hV-Mk-Z83"/>
                 <constraint firstItem="120" firstAttribute="height" secondItem="118" secondAttribute="height" id="AWt-Mn-JaE"/>
                 <constraint firstItem="120" firstAttribute="width" secondItem="118" secondAttribute="width" id="GS7-1t-g4e"/>
                 <constraint firstAttribute="bottom" secondItem="118" secondAttribute="bottom" constant="20" symbolic="YES" id="KpS-7M-Sp2"/>
@@ -509,8 +528,9 @@
                 <constraint firstItem="548" firstAttribute="top" secondItem="409" secondAttribute="bottom" constant="12" id="Yhl-OY-ijT"/>
                 <constraint firstItem="118" firstAttribute="top" secondItem="79" secondAttribute="bottom" constant="8" symbolic="YES" id="axl-k4-as8"/>
                 <constraint firstItem="409" firstAttribute="leading" secondItem="79" secondAttribute="trailing" constant="14" id="cd6-2O-tSr"/>
+                <constraint firstItem="79" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="120" secondAttribute="trailing" id="jsJ-00-yUX"/>
                 <constraint firstItem="79" firstAttribute="top" secondItem="409" secondAttribute="top" id="l0c-7M-VBV"/>
-                <constraint firstItem="548" firstAttribute="centerX" secondItem="409" secondAttribute="centerX" id="oCF-g5-4fi"/>
+                <constraint firstItem="548" firstAttribute="trailing" secondItem="409" secondAttribute="trailing" id="lPt-0q-CcH"/>
                 <constraint firstItem="79" firstAttribute="leading" secondItem="118" secondAttribute="leading" id="qfr-Kc-7Ks"/>
                 <constraint firstItem="120" firstAttribute="leading" secondItem="118" secondAttribute="trailing" constant="-1" id="yfC-lf-5RA"/>
             </constraints>

--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -408,8 +408,8 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Dxg-la-6Uh">
-                                        <rect key="frame" x="32" y="14" width="193" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Update Contact and Via headers" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="cPc-9z-FgQ">
+                                        <rect key="frame" x="32" y="14" width="119" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Update IP address" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="cPc-9z-FgQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -514,6 +514,7 @@
                 <constraint firstItem="79" firstAttribute="leading" secondItem="118" secondAttribute="leading" id="qfr-Kc-7Ks"/>
                 <constraint firstItem="120" firstAttribute="leading" secondItem="118" secondAttribute="trailing" constant="-1" id="yfC-lf-5RA"/>
             </constraints>
+            <point key="canvasLocation" x="139" y="154"/>
         </customView>
     </objects>
     <resources>

--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -18,6 +18,7 @@
                 <outlet property="fullNameField" destination="95" id="511"/>
                 <outlet property="passwordField" destination="104" id="515"/>
                 <outlet property="plusCharacterSubstitutionField" destination="418" id="517"/>
+                <outlet property="plusCharacterSubstitutionLabel" destination="ERB-3b-3jA" id="pi8-uC-6Lj"/>
                 <outlet property="proxyHostField" destination="426" id="518"/>
                 <outlet property="proxyPortField" destination="428" id="519"/>
                 <outlet property="registrarField" destination="97" id="513"/>
@@ -90,11 +91,11 @@
                     <tabViewItems>
                         <tabViewItem label="Account Information" identifier="1" id="410">
                             <view key="view" id="413" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="318" height="271"/>
+                                <rect key="frame" x="10" y="29" width="318" height="267"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="226" width="111" height="18"/>
+                                        <rect key="frame" x="14" y="222" width="111" height="18"/>
                                         <buttonCell key="cell" type="check" title="Use this account" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +105,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="101" y="135" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="131" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +119,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="101" y="77" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="73" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +133,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="36" y="138" width="60" height="14"/>
+                                        <rect key="frame" x="36" y="134" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Full Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +141,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="30" y="80" width="66" height="14"/>
+                                        <rect key="frame" x="30" y="76" width="66" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="User Name:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +149,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="38" y="51" width="58" height="14"/>
+                                        <rect key="frame" x="38" y="47" width="58" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +157,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="101" y="48" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="44" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +171,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="528">
-                                        <rect key="frame" x="101" y="106" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="102" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="529">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +185,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="530">
-                                        <rect key="frame" x="49" y="109" width="47" height="14"/>
+                                        <rect key="frame" x="49" y="105" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="531">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +193,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="534">
-                                        <rect key="frame" x="101" y="174" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="170" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="0P5-QA-beZ"/>
                                         </constraints>
@@ -206,7 +207,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="536">
-                                        <rect key="frame" x="28" y="177" width="68" height="14"/>
+                                        <rect key="frame" x="28" y="173" width="68" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Description:" id="537">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>

--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="108" y="135" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="135" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="108" y="77" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="77" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="43" y="138" width="60" height="14"/>
+                                        <rect key="frame" x="36" y="138" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Full Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="37" y="80" width="66" height="14"/>
+                                        <rect key="frame" x="30" y="80" width="66" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="User Name:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="45" y="51" width="58" height="14"/>
+                                        <rect key="frame" x="38" y="51" width="58" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Password:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="108" y="48" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="48" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="528">
-                                        <rect key="frame" x="108" y="106" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="106" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="529">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="530">
-                                        <rect key="frame" x="56" y="109" width="47" height="14"/>
+                                        <rect key="frame" x="49" y="109" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="531">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="534">
-                                        <rect key="frame" x="108" y="174" width="185" height="19"/>
+                                        <rect key="frame" x="101" y="174" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="0P5-QA-beZ"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="536">
-                                        <rect key="frame" x="35" y="177" width="68" height="14"/>
+                                        <rect key="frame" x="28" y="177" width="68" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Description:" id="537">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -231,7 +231,7 @@
                                     <constraint firstItem="528" firstAttribute="top" secondItem="95" secondAttribute="bottom" constant="10" id="OEP-3x-aSB"/>
                                     <constraint firstItem="103" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="Rs6-0J-VPE"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="UDC-r0-F21"/>
-                                    <constraint firstAttribute="trailing" secondItem="534" secondAttribute="trailing" constant="25" id="WAf-X4-LdX"/>
+                                    <constraint firstAttribute="trailing" secondItem="534" secondAttribute="trailing" constant="32" id="WAf-X4-LdX"/>
                                     <constraint firstItem="534" firstAttribute="leading" secondItem="536" secondAttribute="trailing" constant="7" id="ajg-yi-dBJ"/>
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="av8-w1-KMb"/>
                                     <constraint firstItem="95" firstAttribute="baseline" secondItem="99" secondAttribute="baseline" id="cDS-9v-SZG"/>

--- a/Telephone/UserDefaultsKeys.h
+++ b/Telephone/UserDefaultsKeys.h
@@ -63,4 +63,5 @@ extern NSString * const kProxyHost;
 extern NSString * const kProxyPort;
 extern NSString * const kUpdateContactHeader;
 extern NSString * const kUpdateViaHeader;
+extern NSString * const kUpdateSDP;
 extern NSString * const kLockCodec;

--- a/Telephone/UserDefaultsKeys.m
+++ b/Telephone/UserDefaultsKeys.m
@@ -61,4 +61,5 @@ NSString * const kProxyHost = @"ProxyHost";
 NSString * const kProxyPort = @"ProxyPort";
 NSString * const kUpdateContactHeader = @"UpdateContactHeader";
 NSString * const kUpdateViaHeader = @"UpdateViaHeader";
+NSString * const kUpdateSDP = @"UpdateSDP";
 NSString * const kLockCodec = @"LockCodec";

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -18,6 +18,7 @@
                 <outlet property="fullNameField" destination="95" id="406"/>
                 <outlet property="passwordField" destination="104" id="410"/>
                 <outlet property="plusCharacterSubstitutionField" destination="339" id="412"/>
+                <outlet property="plusCharacterSubstitutionLabel" destination="oOE-ez-BHg" id="PKb-hb-Szg"/>
                 <outlet property="proxyHostField" destination="342" id="413"/>
                 <outlet property="proxyPortField" destination="343" id="414"/>
                 <outlet property="registrarField" destination="97" id="408"/>
@@ -90,11 +91,11 @@
                     <tabViewItems>
                         <tabViewItem label="Account-Informationen" identifier="1" id="334" userLabel="Account Information">
                             <view key="view" id="337" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="350" height="271"/>
+                                <rect key="frame" x="10" y="29" width="350" height="267"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="226" width="165" height="18"/>
+                                        <rect key="frame" x="14" y="222" width="165" height="18"/>
                                         <buttonCell key="cell" type="check" title="Diesen Account verwenden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +105,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="133" y="135" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="131" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +119,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="133" y="77" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="73" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +133,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="18" y="138" width="110" height="14"/>
+                                        <rect key="frame" x="18" y="134" width="110" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Vollständiger Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +141,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="44" y="80" width="84" height="14"/>
+                                        <rect key="frame" x="44" y="76" width="84" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Benutzername:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +149,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="72" y="51" width="56" height="14"/>
+                                        <rect key="frame" x="72" y="47" width="56" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Passwort:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +157,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="133" y="48" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="44" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +171,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="423">
-                                        <rect key="frame" x="133" y="106" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="102" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="424">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +185,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="425">
-                                        <rect key="frame" x="81" y="109" width="47" height="14"/>
+                                        <rect key="frame" x="81" y="105" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="426">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +193,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="427">
-                                        <rect key="frame" x="133" y="174" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="170" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="t9L-tz-LO9"/>
                                         </constraints>
@@ -206,7 +207,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="429">
-                                        <rect key="frame" x="48" y="177" width="80" height="14"/>
+                                        <rect key="frame" x="48" y="173" width="80" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Beschreibung:" id="430">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -32,16 +32,16 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="148" userLabel="Accounts">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="330"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="362"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="79" userLabel="Table">
-                    <rect key="frame" x="20" y="52" width="130" height="264"/>
+                    <rect key="frame" x="20" y="52" width="130" height="296"/>
                     <clipView key="contentView" id="3To-IM-XIB">
-                        <rect key="frame" x="1" y="0.0" width="128" height="263"/>
+                        <rect key="frame" x="1" y="0.0" width="128" height="295"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="83" id="82">
-                                <rect key="frame" x="0.0" y="0.0" width="128" height="240"/>
+                                <rect key="frame" x="0.0" y="0.0" width="128" height="272"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -86,15 +86,15 @@
                     </tableHeaderView>
                 </scrollView>
                 <tabView controlSize="small" initialItem="334" translatesAutoresizingMaskIntoConstraints="NO" id="333" userLabel="Tab View">
-                    <rect key="frame" x="157" y="42" width="370" height="277"/>
+                    <rect key="frame" x="157" y="42" width="370" height="309"/>
                     <tabViewItems>
                         <tabViewItem label="Account-Informationen" identifier="1" id="334" userLabel="Account Information">
                             <view key="view" id="337" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="350" height="239"/>
+                                <rect key="frame" x="10" y="25" width="350" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="205" width="165" height="18"/>
+                                        <rect key="frame" x="14" y="226" width="165" height="18"/>
                                         <buttonCell key="cell" type="check" title="Diesen Account verwenden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="145" y="125" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="135" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="145" y="67" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="77" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="30" y="128" width="110" height="14"/>
+                                        <rect key="frame" x="30" y="138" width="110" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Vollständiger Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="56" y="70" width="84" height="14"/>
+                                        <rect key="frame" x="56" y="80" width="84" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Benutzername:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="84" y="41" width="56" height="14"/>
+                                        <rect key="frame" x="84" y="51" width="56" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Passwort:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="145" y="38" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="48" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="423">
-                                        <rect key="frame" x="145" y="96" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="106" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="424">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="425">
-                                        <rect key="frame" x="93" y="99" width="47" height="14"/>
+                                        <rect key="frame" x="93" y="109" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="426">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="427">
-                                        <rect key="frame" x="145" y="164" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="174" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="t9L-tz-LO9"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="429">
-                                        <rect key="frame" x="60" y="167" width="80" height="14"/>
+                                        <rect key="frame" x="60" y="177" width="80" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Beschreibung:" id="430">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -220,7 +220,7 @@
                                     <constraint firstItem="95" firstAttribute="top" secondItem="427" secondAttribute="bottom" constant="20" id="6gL-fy-arY"/>
                                     <constraint firstItem="429" firstAttribute="baseline" secondItem="427" secondAttribute="baseline" id="8pY-t4-X8j"/>
                                     <constraint firstAttribute="trailing" secondItem="427" secondAttribute="trailing" constant="20" id="A5V-vc-rfr"/>
-                                    <constraint firstItem="93" firstAttribute="top" secondItem="337" secondAttribute="top" constant="19" id="EXZ-Xs-K3Z"/>
+                                    <constraint firstItem="93" firstAttribute="top" secondItem="337" secondAttribute="top" constant="30" id="EXZ-Xs-K3Z"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="425" secondAttribute="trailing" id="G7f-vz-JdN"/>
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="423" secondAttribute="leading" id="Gie-nZ-Bny"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="423" secondAttribute="trailing" id="JO6-fT-bdm"/>
@@ -242,7 +242,7 @@
                                     <constraint firstItem="423" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="hTT-wV-6PY"/>
                                     <constraint firstItem="423" firstAttribute="top" secondItem="95" secondAttribute="bottom" constant="10" id="hXu-g8-tyF"/>
                                     <constraint firstItem="425" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="iju-YX-Ydm"/>
-                                    <constraint firstItem="427" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="25" id="jBW-te-kBZ"/>
+                                    <constraint firstItem="427" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="36" id="jBW-te-kBZ"/>
                                     <constraint firstItem="427" firstAttribute="trailing" secondItem="95" secondAttribute="trailing" id="lL9-Jg-oWt"/>
                                     <constraint firstItem="425" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="x1U-fw-3ER"/>
                                     <constraint firstItem="104" firstAttribute="top" secondItem="98" secondAttribute="bottom" constant="10" id="y7H-Fr-lRe"/>
@@ -252,11 +252,11 @@
                         </tabViewItem>
                         <tabViewItem label="Erweitert" identifier="2" id="335" userLabel="Advanced">
                             <view key="view" id="336" userLabel="Advanced">
-                                <rect key="frame" x="10" y="25" width="350" height="239"/>
+                                <rect key="frame" x="10" y="25" width="350" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="338">
-                                        <rect key="frame" x="24" y="207" width="82" height="18"/>
+                                        <rect key="frame" x="24" y="239" width="82" height="18"/>
                                         <buttonCell key="cell" type="check" title="„+“ durch „" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="355">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -266,7 +266,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="339">
-                                        <rect key="frame" x="104" y="206" width="29" height="19"/>
+                                        <rect key="frame" x="104" y="238" width="29" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="29" id="jrN-FG-4Q7"/>
                                         </constraints>
@@ -283,7 +283,7 @@
                                         </connections>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="341">
-                                        <rect key="frame" x="24" y="92" width="136" height="18"/>
+                                        <rect key="frame" x="24" y="116" width="136" height="18"/>
                                         <buttonCell key="cell" type="check" title="Über Proxy verbinden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="352">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -293,7 +293,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="342">
-                                        <rect key="frame" x="139" y="68" width="185" height="19"/>
+                                        <rect key="frame" x="139" y="92" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="351">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -307,7 +307,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="343">
-                                        <rect key="frame" x="139" y="41" width="43" height="19"/>
+                                        <rect key="frame" x="139" y="65" width="43" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="43" id="2ih-oO-vdK"/>
                                         </constraints>
@@ -324,7 +324,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="344">
-                                        <rect key="frame" x="92" y="71" width="42" height="14"/>
+                                        <rect key="frame" x="92" y="95" width="42" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Server:" id="349">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -332,7 +332,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="345">
-                                        <rect key="frame" x="104" y="44" width="30" height="14"/>
+                                        <rect key="frame" x="104" y="68" width="30" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Port:" id="348">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -340,7 +340,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="392">
-                                        <rect key="frame" x="25" y="180" width="24" height="14"/>
+                                        <rect key="frame" x="25" y="212" width="24" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Alle" id="393">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -348,7 +348,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="394">
-                                        <rect key="frame" x="50" y="177" width="36" height="19"/>
+                                        <rect key="frame" x="50" y="209" width="36" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="36" id="3lU-Lk-B8D"/>
                                         </constraints>
@@ -362,7 +362,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="396">
-                                        <rect key="frame" x="87" y="180" width="133" height="14"/>
+                                        <rect key="frame" x="87" y="212" width="133" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sekunden neu anmelden" id="397">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -370,7 +370,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="96">
-                                        <rect key="frame" x="139" y="148" width="185" height="19"/>
+                                        <rect key="frame" x="139" y="180" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="mMh-je-X5p"/>
                                         </constraints>
@@ -387,7 +387,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="97">
-                                        <rect key="frame" x="139" y="119" width="185" height="19"/>
+                                        <rect key="frame" x="139" y="151" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="112">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -401,7 +401,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                                        <rect key="frame" x="62" y="151" width="72" height="14"/>
+                                        <rect key="frame" x="62" y="183" width="72" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="SIP-Adresse:" id="109">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -409,7 +409,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101">
-                                        <rect key="frame" x="17" y="122" width="117" height="14"/>
+                                        <rect key="frame" x="17" y="154" width="117" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Registrierungsserver:" id="108">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -417,18 +417,26 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Hn9-I1-jbC">
-                                        <rect key="frame" x="24" y="14" width="149" height="18"/>
+                                        <rect key="frame" x="24" y="30" width="149" height="18"/>
                                         <buttonCell key="cell" type="check" title="IP-Adresse aktualisieren" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="Lmh-9J-VT4">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
                                     </button>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oOE-ez-BHg">
-                                        <rect key="frame" x="131" y="209" width="59" height="14"/>
+                                        <rect key="frame" x="131" y="241" width="59" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="“ ersetzen" id="Hrh-WL-jF9">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="o7L-eM-UD2">
+                                        <rect key="frame" x="42" y="14" width="266" height="11"/>
+                                        <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" title="Aktivierung dieser Option kann manche Tonprobleme lösen." id="sZg-Zx-tOJ">
+                                            <font key="font" metaFont="miniSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
                                 </subviews>
@@ -450,24 +458,28 @@
                                     <constraint firstItem="396" firstAttribute="baseline" secondItem="392" secondAttribute="baseline" id="GVW-Oh-Bep"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" id="H4G-x3-H6w"/>
                                     <constraint firstItem="345" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="20" symbolic="YES" id="Jeq-ek-Ket"/>
+                                    <constraint firstItem="o7L-eM-UD2" firstAttribute="top" secondItem="Hn9-I1-jbC" secondAttribute="bottom" constant="8" id="Lek-Op-JRb"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="26" id="LoD-ND-5Gm"/>
                                     <constraint firstItem="101" firstAttribute="trailing" secondItem="344" secondAttribute="trailing" id="MlS-nK-EKv"/>
                                     <constraint firstAttribute="trailing" secondItem="396" secondAttribute="trailing" priority="750" constant="132" id="NL0-at-vDe"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hn9-I1-jbC" secondAttribute="trailing" constant="20" symbolic="YES" id="O4R-Kh-ALa"/>
                                     <constraint firstItem="344" firstAttribute="baseline" secondItem="342" secondAttribute="baseline" id="Oxy-PB-alX"/>
                                     <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="20" symbolic="YES" id="PQb-TZ-xY7"/>
+                                    <constraint firstItem="o7L-eM-UD2" firstAttribute="leading" secondItem="Hn9-I1-jbC" secondAttribute="leading" constant="17" id="QCn-og-wbN"/>
                                     <constraint firstItem="101" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="19" id="QR0-vg-nKH"/>
                                     <constraint firstItem="101" firstAttribute="baseline" secondItem="97" secondAttribute="baseline" id="TDm-ec-DxV"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="341" secondAttribute="trailing" constant="20" symbolic="YES" id="TuN-07-coF"/>
                                     <constraint firstItem="345" firstAttribute="baseline" secondItem="343" secondAttribute="baseline" id="XBZ-m0-OQl"/>
                                     <constraint firstItem="339" firstAttribute="baseline" secondItem="338" secondAttribute="baseline" id="agz-Vh-UsQ"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="100" secondAttribute="trailing" constant="7" id="c7B-i6-Tkt"/>
-                                    <constraint firstItem="341" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="12" id="dDF-fc-6zy"/>
+                                    <constraint firstItem="341" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="20" id="dDF-fc-6zy"/>
                                     <constraint firstItem="344" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="20" symbolic="YES" id="fV0-KJ-o7O"/>
                                     <constraint firstItem="97" firstAttribute="leading" secondItem="342" secondAttribute="leading" id="lcj-RD-r6S"/>
-                                    <constraint firstItem="Hn9-I1-jbC" firstAttribute="top" secondItem="343" secondAttribute="bottom" constant="12" id="nAz-ac-Fif"/>
+                                    <constraint firstItem="Hn9-I1-jbC" firstAttribute="top" secondItem="343" secondAttribute="bottom" constant="20" id="nAz-ac-Fif"/>
                                     <constraint firstAttribute="trailing" secondItem="343" secondAttribute="trailing" priority="750" constant="168" id="odf-Hh-QI6"/>
+                                    <constraint firstAttribute="bottom" secondItem="o7L-eM-UD2" secondAttribute="bottom" constant="14" id="rCb-xW-bKq"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="394" secondAttribute="bottom" constant="10" id="s87-En-ss1"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="o7L-eM-UD2" secondAttribute="trailing" constant="20" symbolic="YES" id="sT9-ve-kNe"/>
                                     <constraint firstItem="394" firstAttribute="leading" secondItem="392" secondAttribute="trailing" constant="3" id="sZG-iK-i1v"/>
                                     <constraint firstItem="396" firstAttribute="leading" secondItem="394" secondAttribute="trailing" constant="3" id="tJe-3F-unW"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="u4R-W8-0Bx"/>

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -411,8 +411,8 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Hn9-I1-jbC">
-                                        <rect key="frame" x="24" y="14" width="217" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Contact und Via Header aktualisieren" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Lmh-9J-VT4">
+                                        <rect key="frame" x="24" y="14" width="149" height="18"/>
+                                        <buttonCell key="cell" type="check" title="IP-Adresse aktualisieren" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Lmh-9J-VT4">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -519,6 +519,7 @@
                 <constraint firstItem="120" firstAttribute="height" secondItem="118" secondAttribute="height" id="vfl-41-Zn0"/>
                 <constraint firstItem="120" firstAttribute="leading" secondItem="118" secondAttribute="trailing" constant="-1" id="xu9-o4-Yeq"/>
             </constraints>
+            <point key="canvasLocation" x="139" y="154"/>
         </customView>
     </objects>
     <resources>

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="145" y="135" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="135" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="145" y="77" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="77" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="30" y="138" width="110" height="14"/>
+                                        <rect key="frame" x="18" y="138" width="110" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Vollständiger Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="56" y="80" width="84" height="14"/>
+                                        <rect key="frame" x="44" y="80" width="84" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Benutzername:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="84" y="51" width="56" height="14"/>
+                                        <rect key="frame" x="72" y="51" width="56" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Passwort:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="145" y="48" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="48" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="423">
-                                        <rect key="frame" x="145" y="106" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="106" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="424">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="425">
-                                        <rect key="frame" x="93" y="109" width="47" height="14"/>
+                                        <rect key="frame" x="81" y="109" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="426">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="427">
-                                        <rect key="frame" x="145" y="174" width="185" height="19"/>
+                                        <rect key="frame" x="133" y="174" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="t9L-tz-LO9"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="429">
-                                        <rect key="frame" x="60" y="177" width="80" height="14"/>
+                                        <rect key="frame" x="48" y="177" width="80" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Beschreibung:" id="430">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -219,7 +219,7 @@
                                     <constraint firstItem="98" firstAttribute="trailing" secondItem="104" secondAttribute="trailing" id="3GJ-Ai-1S5"/>
                                     <constraint firstItem="95" firstAttribute="top" secondItem="427" secondAttribute="bottom" constant="20" id="6gL-fy-arY"/>
                                     <constraint firstItem="429" firstAttribute="baseline" secondItem="427" secondAttribute="baseline" id="8pY-t4-X8j"/>
-                                    <constraint firstAttribute="trailing" secondItem="427" secondAttribute="trailing" constant="20" id="A5V-vc-rfr"/>
+                                    <constraint firstAttribute="trailing" secondItem="427" secondAttribute="trailing" constant="32" id="A5V-vc-rfr"/>
                                     <constraint firstItem="93" firstAttribute="top" secondItem="337" secondAttribute="top" constant="30" id="EXZ-Xs-K3Z"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="425" secondAttribute="trailing" id="G7f-vz-JdN"/>
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="423" secondAttribute="leading" id="Gie-nZ-Bny"/>

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -23,7 +23,7 @@
                 <outlet property="registrarField" destination="97" id="408"/>
                 <outlet property="reregistrationTimeField" destination="394" id="411"/>
                 <outlet property="substitutePlusCharacterCheckBox" destination="338" id="364"/>
-                <outlet property="updateHeadersCheckBox" destination="Hn9-I1-jbC" id="U9v-7J-ucO"/>
+                <outlet property="updateIPAddressCheckBox" destination="Hn9-I1-jbC" id="U9v-7J-ucO"/>
                 <outlet property="useProxyCheckBox" destination="341" id="365"/>
                 <outlet property="usernameField" destination="98" id="409"/>
                 <outlet property="view" destination="148" id="441"/>

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -90,12 +90,12 @@
                     <tabViewItems>
                         <tabViewItem label="Account-Informationen" identifier="1" id="334" userLabel="Account Information">
                             <view key="view" id="337" userLabel="Account Information">
-                                <rect key="frame" x="10" y="29" width="350" height="235"/>
+                                <rect key="frame" x="10" y="25" width="350" height="239"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="201" width="165" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Diesen Account verwenden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" state="on" inset="2" id="94">
+                                        <rect key="frame" x="14" y="205" width="165" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Diesen Account verwenden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="145" y="121" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="125" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="145" y="63" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="67" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="30" y="124" width="110" height="14"/>
+                                        <rect key="frame" x="30" y="128" width="110" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Vollständiger Name:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="56" y="66" width="84" height="14"/>
+                                        <rect key="frame" x="56" y="70" width="84" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Benutzername:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="84" y="37" width="56" height="14"/>
+                                        <rect key="frame" x="84" y="41" width="56" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Passwort:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="145" y="34" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="38" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="423">
-                                        <rect key="frame" x="145" y="92" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="96" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="424">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="425">
-                                        <rect key="frame" x="93" y="95" width="47" height="14"/>
+                                        <rect key="frame" x="93" y="99" width="47" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Domain:" id="426">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="427">
-                                        <rect key="frame" x="145" y="160" width="185" height="19"/>
+                                        <rect key="frame" x="145" y="164" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="t9L-tz-LO9"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="429">
-                                        <rect key="frame" x="60" y="163" width="80" height="14"/>
+                                        <rect key="frame" x="60" y="167" width="80" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Beschreibung:" id="430">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -224,8 +224,12 @@
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="425" secondAttribute="trailing" id="G7f-vz-JdN"/>
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="423" secondAttribute="leading" id="Gie-nZ-Bny"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="423" secondAttribute="trailing" id="JO6-fT-bdm"/>
+                                    <constraint firstItem="103" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="KCW-Jx-xkM"/>
                                     <constraint firstItem="93" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="17" id="LME-dB-19E"/>
                                     <constraint firstItem="98" firstAttribute="top" secondItem="423" secondAttribute="bottom" constant="10" id="NdF-kg-d5P"/>
+                                    <constraint firstItem="102" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="OSs-CK-PNy"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="T3e-TK-P4I"/>
+                                    <constraint firstItem="99" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="Tp7-Nr-nbi"/>
                                     <constraint firstItem="429" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="YLg-6V-Q2m"/>
                                     <constraint firstItem="423" firstAttribute="trailing" secondItem="98" secondAttribute="trailing" id="Zxj-GG-69V"/>
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="aaA-nz-2dJ"/>
@@ -233,9 +237,11 @@
                                     <constraint firstItem="102" firstAttribute="trailing" secondItem="103" secondAttribute="trailing" id="dSw-dz-1nU"/>
                                     <constraint firstItem="103" firstAttribute="baseline" secondItem="104" secondAttribute="baseline" id="fRO-e4-Gp8"/>
                                     <constraint firstItem="102" firstAttribute="baseline" secondItem="98" secondAttribute="baseline" id="fWl-9k-rgQ"/>
+                                    <constraint firstItem="429" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="ftu-A1-445"/>
                                     <constraint firstItem="425" firstAttribute="baseline" secondItem="423" secondAttribute="baseline" id="gK6-9S-fd6"/>
                                     <constraint firstItem="423" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="hTT-wV-6PY"/>
                                     <constraint firstItem="423" firstAttribute="top" secondItem="95" secondAttribute="bottom" constant="10" id="hXu-g8-tyF"/>
+                                    <constraint firstItem="425" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="iju-YX-Ydm"/>
                                     <constraint firstItem="427" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="25" id="jBW-te-kBZ"/>
                                     <constraint firstItem="427" firstAttribute="trailing" secondItem="95" secondAttribute="trailing" id="lL9-Jg-oWt"/>
                                     <constraint firstItem="425" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="x1U-fw-3ER"/>
@@ -251,7 +257,7 @@
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="338">
                                         <rect key="frame" x="24" y="207" width="82" height="18"/>
-                                        <buttonCell key="cell" type="check" title="„+“ durch „" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="355">
+                                        <buttonCell key="cell" type="check" title="„+“ durch „" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="355">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -278,7 +284,7 @@
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="341">
                                         <rect key="frame" x="24" y="92" width="136" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Über Proxy verbinden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="352">
+                                        <buttonCell key="cell" type="check" title="Über Proxy verbinden" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="352">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -303,7 +309,7 @@
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="343">
                                         <rect key="frame" x="139" y="41" width="43" height="19"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="43" id="2ih-oO-vdK"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="43" id="2ih-oO-vdK"/>
                                         </constraints>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="5060" drawsBackground="YES" id="350">
                                             <font key="font" metaFont="smallSystem"/>
@@ -344,7 +350,7 @@
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="394">
                                         <rect key="frame" x="50" y="177" width="36" height="19"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="36" id="3lU-Lk-B8D"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="36" id="3lU-Lk-B8D"/>
                                         </constraints>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="300" drawsBackground="YES" id="395">
                                             <font key="font" metaFont="smallSystem"/>
@@ -412,7 +418,7 @@
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="Hn9-I1-jbC">
                                         <rect key="frame" x="24" y="14" width="149" height="18"/>
-                                        <buttonCell key="cell" type="check" title="IP-Adresse aktualisieren" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="Lmh-9J-VT4">
+                                        <buttonCell key="cell" type="check" title="IP-Adresse aktualisieren" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="Lmh-9J-VT4">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -432,6 +438,7 @@
                                     <constraint firstItem="97" firstAttribute="trailing" secondItem="342" secondAttribute="trailing" id="57u-Xm-byS"/>
                                     <constraint firstItem="341" firstAttribute="leading" secondItem="Hn9-I1-jbC" secondAttribute="leading" id="60b-Eg-ZR4"/>
                                     <constraint firstItem="oOE-ez-BHg" firstAttribute="leading" secondItem="339" secondAttribute="trailing" id="715-Jc-AYd"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oOE-ez-BHg" secondAttribute="trailing" constant="20" symbolic="YES" id="74Q-0A-DQ0"/>
                                     <constraint firstItem="oOE-ez-BHg" firstAttribute="baseline" secondItem="338" secondAttribute="baseline" id="7Uc-Te-zVW"/>
                                     <constraint firstItem="394" firstAttribute="top" secondItem="339" secondAttribute="bottom" constant="10" id="8g6-0W-LvD"/>
                                     <constraint firstItem="343" firstAttribute="top" secondItem="342" secondAttribute="bottom" constant="8" symbolic="YES" id="CjR-lZ-MoN"/>
@@ -442,16 +449,24 @@
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="338" secondAttribute="trailing" id="Fm5-FG-cWx"/>
                                     <constraint firstItem="396" firstAttribute="baseline" secondItem="392" secondAttribute="baseline" id="GVW-Oh-Bep"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" id="H4G-x3-H6w"/>
+                                    <constraint firstItem="345" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="20" symbolic="YES" id="Jeq-ek-Ket"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="26" id="LoD-ND-5Gm"/>
                                     <constraint firstItem="101" firstAttribute="trailing" secondItem="344" secondAttribute="trailing" id="MlS-nK-EKv"/>
+                                    <constraint firstAttribute="trailing" secondItem="396" secondAttribute="trailing" priority="750" constant="132" id="NL0-at-vDe"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hn9-I1-jbC" secondAttribute="trailing" constant="20" symbolic="YES" id="O4R-Kh-ALa"/>
                                     <constraint firstItem="344" firstAttribute="baseline" secondItem="342" secondAttribute="baseline" id="Oxy-PB-alX"/>
+                                    <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="20" symbolic="YES" id="PQb-TZ-xY7"/>
+                                    <constraint firstItem="101" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="19" id="QR0-vg-nKH"/>
                                     <constraint firstItem="101" firstAttribute="baseline" secondItem="97" secondAttribute="baseline" id="TDm-ec-DxV"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="341" secondAttribute="trailing" constant="20" symbolic="YES" id="TuN-07-coF"/>
                                     <constraint firstItem="345" firstAttribute="baseline" secondItem="343" secondAttribute="baseline" id="XBZ-m0-OQl"/>
                                     <constraint firstItem="339" firstAttribute="baseline" secondItem="338" secondAttribute="baseline" id="agz-Vh-UsQ"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="100" secondAttribute="trailing" constant="7" id="c7B-i6-Tkt"/>
                                     <constraint firstItem="341" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="12" id="dDF-fc-6zy"/>
+                                    <constraint firstItem="344" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="336" secondAttribute="leading" constant="20" symbolic="YES" id="fV0-KJ-o7O"/>
                                     <constraint firstItem="97" firstAttribute="leading" secondItem="342" secondAttribute="leading" id="lcj-RD-r6S"/>
                                     <constraint firstItem="Hn9-I1-jbC" firstAttribute="top" secondItem="343" secondAttribute="bottom" constant="12" id="nAz-ac-Fif"/>
+                                    <constraint firstAttribute="trailing" secondItem="343" secondAttribute="trailing" priority="750" constant="168" id="odf-Hh-QI6"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="394" secondAttribute="bottom" constant="10" id="s87-En-ss1"/>
                                     <constraint firstItem="394" firstAttribute="leading" secondItem="392" secondAttribute="trailing" constant="3" id="sZG-iK-i1v"/>
                                     <constraint firstItem="396" firstAttribute="leading" secondItem="394" secondAttribute="trailing" constant="3" id="tJe-3F-unW"/>
@@ -459,6 +474,7 @@
                                     <constraint firstItem="344" firstAttribute="trailing" secondItem="345" secondAttribute="trailing" id="vHP-am-xoW"/>
                                     <constraint firstItem="394" firstAttribute="baseline" secondItem="392" secondAttribute="baseline" id="vTp-8I-NKf"/>
                                     <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="vnG-9m-KiE"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="396" secondAttribute="trailing" constant="20" symbolic="YES" id="yyg-sD-BIm"/>
                                     <constraint firstItem="342" firstAttribute="top" secondItem="341" secondAttribute="bottom" constant="8" symbolic="YES" id="z17-IH-Umi"/>
                                     <constraint firstItem="338" firstAttribute="leading" secondItem="336" secondAttribute="leading" constant="27" id="zfS-A4-5Z9"/>
                                 </constraints>
@@ -469,7 +485,7 @@
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="118" userLabel="Add Account">
                     <rect key="frame" x="20" y="22" width="23" height="23"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="23" id="n3f-Cm-JbO"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="23" id="n3f-Cm-JbO"/>
                         <constraint firstAttribute="height" constant="21" id="s7N-wr-s1g"/>
                     </constraints>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="119">
@@ -491,10 +507,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="444" userLabel="Cant Edit Account">
-                    <rect key="frame" x="183" y="14" width="319" height="28"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="315" id="5we-AG-nFf"/>
-                    </constraints>
+                    <rect key="frame" x="180" y="14" width="324" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Die Accounteinstellungen können während der Verwendung nicht verändert werden." id="445">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -504,17 +517,19 @@
             </subviews>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="333" secondAttribute="trailing" constant="20" symbolic="YES" id="4V7-5y-bvr"/>
-                <constraint firstItem="444" firstAttribute="centerX" secondItem="333" secondAttribute="centerX" id="7SV-So-a4o"/>
                 <constraint firstItem="79" firstAttribute="top" secondItem="333" secondAttribute="top" id="7xT-EZ-PNt"/>
                 <constraint firstItem="79" firstAttribute="bottom" secondItem="333" secondAttribute="bottom" id="9LR-hq-Cee"/>
                 <constraint firstAttribute="bottom" secondItem="118" secondAttribute="bottom" constant="23" id="AYd-0z-RJ1"/>
                 <constraint firstItem="333" firstAttribute="leading" secondItem="79" secondAttribute="trailing" constant="14" id="B2Q-qV-uP2"/>
                 <constraint firstItem="79" firstAttribute="top" secondItem="148" secondAttribute="top" constant="14" id="BuH-w2-oxM"/>
+                <constraint firstItem="79" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="120" secondAttribute="trailing" id="YFM-hb-elx"/>
+                <constraint firstItem="444" firstAttribute="trailing" secondItem="333" secondAttribute="trailing" constant="-18" id="ZWa-nl-BWj"/>
                 <constraint firstItem="118" firstAttribute="top" secondItem="79" secondAttribute="bottom" constant="8" symbolic="YES" id="cE7-5L-VfN"/>
                 <constraint firstItem="120" firstAttribute="centerY" secondItem="118" secondAttribute="centerY" id="cTI-pB-6a5"/>
                 <constraint firstItem="444" firstAttribute="top" secondItem="333" secondAttribute="bottom" constant="10" id="dqH-cA-d0U"/>
                 <constraint firstItem="79" firstAttribute="leading" secondItem="148" secondAttribute="leading" constant="20" symbolic="YES" id="ezo-rg-j74"/>
                 <constraint firstItem="79" firstAttribute="leading" secondItem="118" secondAttribute="leading" id="ooi-FK-i5A"/>
+                <constraint firstItem="444" firstAttribute="leading" secondItem="333" secondAttribute="leading" constant="18" id="rha-Pf-4Cp"/>
                 <constraint firstItem="120" firstAttribute="width" secondItem="118" secondAttribute="width" id="tod-ZQ-IAS"/>
                 <constraint firstItem="120" firstAttribute="height" secondItem="118" secondAttribute="height" id="vfl-41-Zn0"/>
                 <constraint firstItem="120" firstAttribute="leading" secondItem="118" secondAttribute="trailing" constant="-1" id="xu9-o4-Yeq"/>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -32,16 +32,16 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="148" userLabel="Accounts">
-            <rect key="frame" x="0.0" y="0.0" width="541" height="352"/>
+            <rect key="frame" x="0.0" y="0.0" width="540" height="359"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="79" userLabel="Table">
-                    <rect key="frame" x="20" y="49" width="130" height="289"/>
+                    <rect key="frame" x="20" y="49" width="130" height="296"/>
                     <clipView key="contentView" id="AvC-ic-rCh">
-                        <rect key="frame" x="1" y="0.0" width="128" height="288"/>
+                        <rect key="frame" x="1" y="0.0" width="128" height="295"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="83" id="82">
-                                <rect key="frame" x="0.0" y="0.0" width="128" height="265"/>
+                                <rect key="frame" x="0.0" y="0.0" width="128" height="272"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -86,15 +86,15 @@
                     </tableHeaderView>
                 </scrollView>
                 <tabView controlSize="small" initialItem="335" translatesAutoresizingMaskIntoConstraints="NO" id="334" userLabel="Tab View">
-                    <rect key="frame" x="157" y="39" width="371" height="302"/>
+                    <rect key="frame" x="157" y="39" width="370" height="309"/>
                     <tabViewItems>
                         <tabViewItem label="Информация" identifier="1" id="335" userLabel="Account Information">
                             <view key="view" id="338" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="351" height="264"/>
+                                <rect key="frame" x="10" y="25" width="350" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="219" width="99" height="18"/>
+                                        <rect key="frame" x="14" y="226" width="99" height="18"/>
                                         <buttonCell key="cell" type="check" title="Использовать" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="144" y="128" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="135" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="144" y="70" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="77" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="39" y="131" width="99" height="14"/>
+                                        <rect key="frame" x="21" y="138" width="99" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Имя с фамилией:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="55" y="73" width="83" height="14"/>
+                                        <rect key="frame" x="37" y="80" width="83" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пользователь:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="90" y="44" width="48" height="14"/>
+                                        <rect key="frame" x="72" y="51" width="48" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пароль:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="144" y="41" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="48" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="426">
-                                        <rect key="frame" x="144" y="99" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="106" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="427">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="428">
-                                        <rect key="frame" x="94" y="102" width="44" height="14"/>
+                                        <rect key="frame" x="76" y="109" width="44" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Домен:" id="429">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="430">
-                                        <rect key="frame" x="144" y="167" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="174" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="NpR-uH-HqX"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="432">
-                                        <rect key="frame" x="78" y="170" width="60" height="14"/>
+                                        <rect key="frame" x="60" y="177" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Название:" id="433">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -226,12 +226,12 @@
                                     <constraint firstItem="430" firstAttribute="leading" secondItem="95" secondAttribute="leading" id="C77-QG-Ofb"/>
                                     <constraint firstItem="93" firstAttribute="top" secondItem="338" secondAttribute="top" constant="30" id="D5J-pJ-w0H"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="GPy-18-xrB"/>
-                                    <constraint firstItem="430" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="432" secondAttribute="trailing" constant="8" symbolic="YES" id="HQk-6c-c3o"/>
+                                    <constraint firstItem="430" firstAttribute="leading" secondItem="432" secondAttribute="trailing" constant="7" id="HQk-6c-c3o"/>
                                     <constraint firstItem="103" firstAttribute="baseline" secondItem="104" secondAttribute="baseline" id="I0w-XP-Rqn"/>
                                     <constraint firstItem="104" firstAttribute="top" secondItem="98" secondAttribute="bottom" constant="10" id="IZ0-0E-38Q"/>
                                     <constraint firstItem="99" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="Klx-p3-op3"/>
                                     <constraint firstItem="432" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="Mtp-BO-Mb0"/>
-                                    <constraint firstAttribute="trailing" secondItem="430" secondAttribute="trailing" constant="22" id="Njn-4j-Xir"/>
+                                    <constraint firstAttribute="trailing" secondItem="430" secondAttribute="trailing" constant="40" id="Njn-4j-Xir"/>
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="ObC-W9-79u"/>
                                     <constraint firstItem="98" firstAttribute="trailing" secondItem="104" secondAttribute="trailing" id="QZr-nm-wWD"/>
                                     <constraint firstItem="103" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="TP1-gs-TNa"/>
@@ -240,7 +240,7 @@
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="426" secondAttribute="leading" id="fJa-rs-foZ"/>
                                     <constraint firstItem="428" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="fqO-Lt-pfp"/>
                                     <constraint firstItem="432" firstAttribute="baseline" secondItem="430" secondAttribute="baseline" id="hcJ-q7-fmJ"/>
-                                    <constraint firstItem="432" firstAttribute="leading" secondItem="338" secondAttribute="leading" constant="80" id="jvm-g9-bVs"/>
+                                    <constraint firstItem="432" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="jvm-g9-bVs"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="426" secondAttribute="trailing" id="m1U-9L-zNF"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="428" secondAttribute="trailing" id="mpk-Rn-cRY"/>
                                     <constraint firstItem="430" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="36" id="nsu-Mq-rjL"/>
@@ -252,7 +252,7 @@
                         </tabViewItem>
                         <tabViewItem label="Дополнительно" identifier="2" id="336" userLabel="Advanced">
                             <view key="view" id="337" userLabel="Advanced">
-                                <rect key="frame" x="10" y="25" width="351" height="271"/>
+                                <rect key="frame" x="10" y="25" width="350" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="339">
@@ -453,8 +453,8 @@
                                     <constraint firstItem="395" firstAttribute="leading" secondItem="397" secondAttribute="trailing" constant="3" id="DTT-Yd-ZZT"/>
                                     <constraint firstItem="351" firstAttribute="baseline" secondItem="349" secondAttribute="baseline" id="IME-ZC-RR7"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="eRv-wi-Jsp" secondAttribute="trailing" constant="20" symbolic="YES" id="IkV-AZ-7mW"/>
-                                    <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="24" id="K5f-yM-Us9"/>
-                                    <constraint firstAttribute="trailing" secondItem="349" secondAttribute="trailing" priority="750" constant="168" id="KVW-PJ-SLK"/>
+                                    <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="23" id="K5f-yM-Us9"/>
+                                    <constraint firstAttribute="trailing" secondItem="349" secondAttribute="trailing" priority="750" constant="167" id="KVW-PJ-SLK"/>
                                     <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="Kxb-ua-svC"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iap-Lu-jWN" secondAttribute="trailing" constant="20" symbolic="YES" id="Lzk-bY-Mz6"/>
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="347" secondAttribute="leading" id="M24-Sx-3fa"/>
@@ -463,7 +463,7 @@
                                     <constraint firstItem="399" firstAttribute="baseline" secondItem="397" secondAttribute="baseline" id="OPr-qd-Gth"/>
                                     <constraint firstItem="349" firstAttribute="top" secondItem="348" secondAttribute="bottom" constant="8" symbolic="YES" id="OUH-Sa-eDu"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="100" secondAttribute="trailing" constant="7" id="PkT-fV-nP1"/>
-                                    <constraint firstAttribute="trailing" secondItem="399" secondAttribute="trailing" priority="750" constant="64" id="S8j-cf-hHk"/>
+                                    <constraint firstAttribute="trailing" secondItem="399" secondAttribute="trailing" priority="750" constant="63" id="S8j-cf-hHk"/>
                                     <constraint firstItem="97" firstAttribute="leading" secondItem="348" secondAttribute="leading" id="Y1Z-NE-JIC"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="Y6F-KW-7Ff"/>
                                     <constraint firstAttribute="bottom" secondItem="iap-Lu-jWN" secondAttribute="bottom" constant="14" id="YbC-4O-FjM"/>
@@ -518,7 +518,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="446" userLabel="Cant Edit Account">
-                    <rect key="frame" x="162" y="23" width="361" height="14"/>
+                    <rect key="frame" x="162" y="23" width="360" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Нельзя настраивать аккаунт во время его использования." id="447">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -545,7 +545,7 @@
                 <constraint firstItem="446" firstAttribute="trailing" secondItem="334" secondAttribute="trailing" id="jpA-2X-hG8"/>
                 <constraint firstItem="446" firstAttribute="leading" secondItem="334" secondAttribute="leading" id="uIc-LB-QMV"/>
             </constraints>
-            <point key="canvasLocation" x="139" y="154"/>
+            <point key="canvasLocation" x="138.5" y="153.5"/>
         </customView>
     </objects>
     <resources>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -32,16 +32,16 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="148" userLabel="Accounts">
-            <rect key="frame" x="0.0" y="0.0" width="541" height="327"/>
+            <rect key="frame" x="0.0" y="0.0" width="541" height="352"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="79" userLabel="Table">
-                    <rect key="frame" x="20" y="49" width="130" height="264"/>
+                    <rect key="frame" x="20" y="49" width="130" height="289"/>
                     <clipView key="contentView" id="AvC-ic-rCh">
-                        <rect key="frame" x="1" y="0.0" width="128" height="263"/>
+                        <rect key="frame" x="1" y="0.0" width="128" height="288"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="83" id="82">
-                                <rect key="frame" x="0.0" y="0.0" width="128" height="240"/>
+                                <rect key="frame" x="0.0" y="0.0" width="128" height="265"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -86,15 +86,15 @@
                     </tableHeaderView>
                 </scrollView>
                 <tabView controlSize="small" initialItem="335" translatesAutoresizingMaskIntoConstraints="NO" id="334" userLabel="Tab View">
-                    <rect key="frame" x="157" y="39" width="371" height="277"/>
+                    <rect key="frame" x="157" y="39" width="371" height="302"/>
                     <tabViewItems>
                         <tabViewItem label="Информация" identifier="1" id="335" userLabel="Account Information">
                             <view key="view" id="338" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="351" height="239"/>
+                                <rect key="frame" x="10" y="25" width="351" height="264"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="205" width="99" height="18"/>
+                                        <rect key="frame" x="14" y="219" width="99" height="18"/>
                                         <buttonCell key="cell" type="check" title="Использовать" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="144" y="125" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="128" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="144" y="67" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="70" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="39" y="128" width="99" height="14"/>
+                                        <rect key="frame" x="39" y="131" width="99" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Имя с фамилией:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="55" y="70" width="83" height="14"/>
+                                        <rect key="frame" x="55" y="73" width="83" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пользователь:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="90" y="41" width="48" height="14"/>
+                                        <rect key="frame" x="90" y="44" width="48" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пароль:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="144" y="38" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="41" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="426">
-                                        <rect key="frame" x="144" y="96" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="99" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="427">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="428">
-                                        <rect key="frame" x="94" y="99" width="44" height="14"/>
+                                        <rect key="frame" x="94" y="102" width="44" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Домен:" id="429">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="430">
-                                        <rect key="frame" x="144" y="164" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="167" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="NpR-uH-HqX"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="432">
-                                        <rect key="frame" x="78" y="167" width="60" height="14"/>
+                                        <rect key="frame" x="78" y="170" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Название:" id="433">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -224,7 +224,7 @@
                                     <constraint firstItem="102" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="97j-LB-E3M"/>
                                     <constraint firstItem="98" firstAttribute="top" secondItem="426" secondAttribute="bottom" constant="10" id="AKy-wr-3Ad"/>
                                     <constraint firstItem="430" firstAttribute="leading" secondItem="95" secondAttribute="leading" id="C77-QG-Ofb"/>
-                                    <constraint firstItem="93" firstAttribute="top" secondItem="338" secondAttribute="top" constant="19" id="D5J-pJ-w0H"/>
+                                    <constraint firstItem="93" firstAttribute="top" secondItem="338" secondAttribute="top" constant="30" id="D5J-pJ-w0H"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="GPy-18-xrB"/>
                                     <constraint firstItem="430" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="432" secondAttribute="trailing" constant="8" symbolic="YES" id="HQk-6c-c3o"/>
                                     <constraint firstItem="103" firstAttribute="baseline" secondItem="104" secondAttribute="baseline" id="I0w-XP-Rqn"/>
@@ -243,7 +243,7 @@
                                     <constraint firstItem="432" firstAttribute="leading" secondItem="338" secondAttribute="leading" constant="80" id="jvm-g9-bVs"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="426" secondAttribute="trailing" id="m1U-9L-zNF"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="428" secondAttribute="trailing" id="mpk-Rn-cRY"/>
-                                    <constraint firstItem="430" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="25" id="nsu-Mq-rjL"/>
+                                    <constraint firstItem="430" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="36" id="nsu-Mq-rjL"/>
                                     <constraint firstItem="426" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="qLW-sY-iUw"/>
                                     <constraint firstItem="428" firstAttribute="baseline" secondItem="426" secondAttribute="baseline" id="ruQ-kH-On4"/>
                                     <constraint firstItem="428" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="zMO-Gg-rnb"/>
@@ -252,11 +252,11 @@
                         </tabViewItem>
                         <tabViewItem label="Дополнительно" identifier="2" id="336" userLabel="Advanced">
                             <view key="view" id="337" userLabel="Advanced">
-                                <rect key="frame" x="10" y="25" width="351" height="239"/>
+                                <rect key="frame" x="10" y="25" width="351" height="271"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="339">
-                                        <rect key="frame" x="24" y="207" width="127" height="18"/>
+                                        <rect key="frame" x="24" y="239" width="127" height="18"/>
                                         <buttonCell key="cell" type="check" title="Заменять «+» на «" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="346">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -266,7 +266,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="340">
-                                        <rect key="frame" x="149" y="206" width="29" height="19"/>
+                                        <rect key="frame" x="149" y="238" width="29" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="29" id="k6g-I6-cTS"/>
                                         </constraints>
@@ -283,7 +283,7 @@
                                         </connections>
                                     </textField>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eRv-wi-Jsp">
-                                        <rect key="frame" x="176" y="209" width="12" height="14"/>
+                                        <rect key="frame" x="176" y="241" width="12" height="14"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="»" id="4CH-zT-iIy">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -291,7 +291,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="347">
-                                        <rect key="frame" x="24" y="92" width="170" height="18"/>
+                                        <rect key="frame" x="24" y="116" width="170" height="18"/>
                                         <buttonCell key="cell" type="check" title="Соединяться через прокси" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="356">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -301,7 +301,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="348">
-                                        <rect key="frame" x="140" y="68" width="187" height="19"/>
+                                        <rect key="frame" x="140" y="92" width="187" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="355">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -315,7 +315,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="349">
-                                        <rect key="frame" x="140" y="41" width="43" height="19"/>
+                                        <rect key="frame" x="140" y="65" width="43" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="43" id="TlP-zO-3o0"/>
                                         </constraints>
@@ -332,7 +332,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="350">
-                                        <rect key="frame" x="86" y="71" width="49" height="14"/>
+                                        <rect key="frame" x="86" y="95" width="49" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Сервер:" id="353">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -340,7 +340,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="351">
-                                        <rect key="frame" x="100" y="44" width="35" height="14"/>
+                                        <rect key="frame" x="100" y="68" width="35" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" enabled="NO" sendsActionOnEndEditing="YES" title="Порт:" id="352">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -348,7 +348,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="395">
-                                        <rect key="frame" x="209" y="177" width="36" height="19"/>
+                                        <rect key="frame" x="209" y="209" width="36" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="36" id="e1t-sL-MCg"/>
                                         </constraints>
@@ -362,7 +362,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="397">
-                                        <rect key="frame" x="24" y="180" width="184" height="14"/>
+                                        <rect key="frame" x="24" y="212" width="184" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Обновлять регистрацию каждые" id="398">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -370,7 +370,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="399">
-                                        <rect key="frame" x="246" y="180" width="43" height="14"/>
+                                        <rect key="frame" x="246" y="212" width="43" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="секунд" id="400">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -378,7 +378,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="96">
-                                        <rect key="frame" x="140" y="148" width="187" height="19"/>
+                                        <rect key="frame" x="140" y="180" width="187" height="19"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="113">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -392,7 +392,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="97">
-                                        <rect key="frame" x="140" y="119" width="187" height="19"/>
+                                        <rect key="frame" x="140" y="151" width="187" height="19"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="112">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -406,7 +406,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="100">
-                                        <rect key="frame" x="72" y="151" width="63" height="14"/>
+                                        <rect key="frame" x="72" y="183" width="63" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="SIP-адрес:" id="109">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -414,7 +414,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="101">
-                                        <rect key="frame" x="13" y="122" width="122" height="14"/>
+                                        <rect key="frame" x="13" y="154" width="122" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Сервер регистраций:" id="108">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -422,17 +422,25 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="eo2-Ed-G06">
-                                        <rect key="frame" x="24" y="14" width="132" height="18"/>
+                                        <rect key="frame" x="24" y="30" width="132" height="18"/>
                                         <buttonCell key="cell" type="check" title="Обновлять IP-адрес" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="gW3-9r-bYQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
                                     </button>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iap-Lu-jWN">
+                                        <rect key="frame" x="43" y="14" width="224" height="11"/>
+                                        <textFieldCell key="cell" controlSize="mini" lineBreakMode="clipping" title="Может решить некоторые проблемы со звуком." id="SZk-jh-2fH">
+                                            <font key="font" metaFont="miniSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="348" firstAttribute="top" secondItem="347" secondAttribute="bottom" constant="8" symbolic="YES" id="0dM-vV-WUb"/>
                                     <constraint firstItem="347" firstAttribute="leading" secondItem="eo2-Ed-G06" secondAttribute="leading" id="0wZ-7f-ldq"/>
-                                    <constraint firstItem="347" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="12" id="10G-IR-Q0t"/>
+                                    <constraint firstItem="347" firstAttribute="top" secondItem="97" secondAttribute="bottom" constant="20" id="10G-IR-Q0t"/>
                                     <constraint firstItem="395" firstAttribute="baseline" secondItem="397" secondAttribute="baseline" id="2Rl-G1-NNS"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="395" secondAttribute="bottom" constant="10" id="3p8-Wf-8y9"/>
                                     <constraint firstItem="350" firstAttribute="trailing" secondItem="351" secondAttribute="trailing" id="4Sp-FL-yOI"/>
@@ -448,6 +456,7 @@
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="24" id="K5f-yM-Us9"/>
                                     <constraint firstAttribute="trailing" secondItem="349" secondAttribute="trailing" priority="750" constant="168" id="KVW-PJ-SLK"/>
                                     <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="Kxb-ua-svC"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iap-Lu-jWN" secondAttribute="trailing" constant="20" symbolic="YES" id="Lzk-bY-Mz6"/>
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="347" secondAttribute="leading" id="M24-Sx-3fa"/>
                                     <constraint firstItem="340" firstAttribute="leading" secondItem="339" secondAttribute="trailing" id="M6b-8g-OvD"/>
                                     <constraint firstItem="395" firstAttribute="top" secondItem="340" secondAttribute="bottom" constant="10" id="O9D-Ft-2do"/>
@@ -457,12 +466,14 @@
                                     <constraint firstAttribute="trailing" secondItem="399" secondAttribute="trailing" priority="750" constant="64" id="S8j-cf-hHk"/>
                                     <constraint firstItem="97" firstAttribute="leading" secondItem="348" secondAttribute="leading" id="Y1Z-NE-JIC"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="Y6F-KW-7Ff"/>
+                                    <constraint firstAttribute="bottom" secondItem="iap-Lu-jWN" secondAttribute="bottom" constant="14" id="YbC-4O-FjM"/>
                                     <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="Yxl-9Z-Vew"/>
                                     <constraint firstItem="340" firstAttribute="baseline" secondItem="339" secondAttribute="baseline" id="bEI-OX-62Q"/>
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="27" id="bbM-qQ-Svr"/>
                                     <constraint firstItem="340" firstAttribute="top" secondItem="337" secondAttribute="top" constant="14" id="blw-xd-2WF"/>
                                     <constraint firstItem="eRv-wi-Jsp" firstAttribute="baseline" secondItem="339" secondAttribute="baseline" id="cKH-um-2OR"/>
                                     <constraint firstItem="350" firstAttribute="baseline" secondItem="348" secondAttribute="baseline" id="cvF-n2-TgX"/>
+                                    <constraint firstItem="iap-Lu-jWN" firstAttribute="top" secondItem="eo2-Ed-G06" secondAttribute="bottom" constant="8" id="d1q-jT-2HA"/>
                                     <constraint firstItem="96" firstAttribute="trailing" secondItem="97" secondAttribute="trailing" id="fnl-hB-D6b"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="349" secondAttribute="trailing" constant="20" symbolic="YES" id="g7g-wd-kv1"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="399" secondAttribute="trailing" constant="20" symbolic="YES" id="im8-JC-AWW"/>
@@ -470,7 +481,8 @@
                                     <constraint firstItem="399" firstAttribute="leading" secondItem="395" secondAttribute="trailing" constant="3" id="oAe-6B-eNx"/>
                                     <constraint firstItem="348" firstAttribute="leading" secondItem="349" secondAttribute="leading" id="q9R-qm-i6k"/>
                                     <constraint firstItem="397" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="26" id="rTN-X7-ef7"/>
-                                    <constraint firstItem="eo2-Ed-G06" firstAttribute="top" secondItem="349" secondAttribute="bottom" constant="12" id="wmF-hQ-uRb"/>
+                                    <constraint firstItem="iap-Lu-jWN" firstAttribute="leading" secondItem="eo2-Ed-G06" secondAttribute="leading" constant="18" id="w3L-N8-AHE"/>
+                                    <constraint firstItem="eo2-Ed-G06" firstAttribute="top" secondItem="349" secondAttribute="bottom" constant="20" id="wmF-hQ-uRb"/>
                                     <constraint firstItem="97" firstAttribute="trailing" secondItem="348" secondAttribute="trailing" id="wqD-Md-5F4"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="347" secondAttribute="trailing" constant="20" symbolic="YES" id="xdv-iQ-bVS"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" symbolic="YES" id="ygR-RC-QCL"/>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15400" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15400"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -416,8 +416,8 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="eo2-Ed-G06">
-                                        <rect key="frame" x="24" y="14" width="214" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Обновлять заголовки Contact и Via" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="gW3-9r-bYQ">
+                                        <rect key="frame" x="24" y="14" width="132" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Обновлять IP-адрес" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="gW3-9r-bYQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -514,6 +514,7 @@
                 <constraint firstItem="118" firstAttribute="top" secondItem="79" secondAttribute="bottom" constant="8" symbolic="YES" id="ilZ-7h-wTd"/>
                 <constraint firstItem="446" firstAttribute="centerX" secondItem="334" secondAttribute="centerX" id="xvm-K2-sVa"/>
             </constraints>
+            <point key="canvasLocation" x="139" y="154"/>
         </customView>
     </objects>
     <resources>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -23,7 +23,7 @@
                 <outlet property="registrarField" destination="97" id="411"/>
                 <outlet property="reregistrationTimeField" destination="395" id="414"/>
                 <outlet property="substitutePlusCharacterCheckBox" destination="339" id="359"/>
-                <outlet property="updateHeadersCheckBox" destination="eo2-Ed-G06" id="3p6-iF-ZDM"/>
+                <outlet property="updateIPAddressCheckBox" destination="eo2-Ed-G06" id="3p6-iF-ZDM"/>
                 <outlet property="useProxyCheckBox" destination="347" id="367"/>
                 <outlet property="usernameField" destination="98" id="412"/>
                 <outlet property="view" destination="148" id="445"/>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -32,7 +32,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="148" userLabel="Accounts">
-            <rect key="frame" x="0.0" y="0.0" width="540" height="327"/>
+            <rect key="frame" x="0.0" y="0.0" width="541" height="327"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="79" userLabel="Table">
                     <rect key="frame" x="20" y="49" width="130" height="264"/>
@@ -86,16 +86,16 @@
                     </tableHeaderView>
                 </scrollView>
                 <tabView controlSize="small" initialItem="335" translatesAutoresizingMaskIntoConstraints="NO" id="334" userLabel="Tab View">
-                    <rect key="frame" x="157" y="39" width="370" height="277"/>
+                    <rect key="frame" x="157" y="39" width="371" height="277"/>
                     <tabViewItems>
                         <tabViewItem label="Информация" identifier="1" id="335" userLabel="Account Information">
                             <view key="view" id="338" userLabel="Account Information">
-                                <rect key="frame" x="10" y="29" width="350" height="235"/>
+                                <rect key="frame" x="10" y="25" width="351" height="239"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="201" width="99" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Использовать" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" state="on" inset="2" id="94">
+                                        <rect key="frame" x="14" y="205" width="99" height="18"/>
+                                        <buttonCell key="cell" type="check" title="Использовать" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="143" y="121" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="125" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +118,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="143" y="63" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="67" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +132,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="39" y="124" width="99" height="14"/>
+                                        <rect key="frame" x="39" y="128" width="99" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Имя с фамилией:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +140,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="55" y="66" width="83" height="14"/>
+                                        <rect key="frame" x="55" y="70" width="83" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пользователь:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +148,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="90" y="37" width="48" height="14"/>
+                                        <rect key="frame" x="90" y="41" width="48" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пароль:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +156,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="143" y="34" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="38" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +170,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="426">
-                                        <rect key="frame" x="143" y="92" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="96" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="427">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +184,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="428">
-                                        <rect key="frame" x="94" y="95" width="44" height="14"/>
+                                        <rect key="frame" x="94" y="99" width="44" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Домен:" id="429">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +192,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="430">
-                                        <rect key="frame" x="143" y="160" width="185" height="19"/>
+                                        <rect key="frame" x="144" y="164" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="NpR-uH-HqX"/>
                                         </constraints>
@@ -206,7 +206,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="432">
-                                        <rect key="frame" x="78" y="163" width="60" height="14"/>
+                                        <rect key="frame" x="78" y="167" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Название:" id="433">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -221,37 +221,43 @@
                                     <constraint firstItem="426" firstAttribute="trailing" secondItem="98" secondAttribute="trailing" id="7PY-Np-Ecn"/>
                                     <constraint firstItem="430" firstAttribute="trailing" secondItem="95" secondAttribute="trailing" id="8WQ-7U-dSG"/>
                                     <constraint firstItem="426" firstAttribute="top" secondItem="95" secondAttribute="bottom" constant="10" id="938-mc-m0O"/>
+                                    <constraint firstItem="102" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="97j-LB-E3M"/>
                                     <constraint firstItem="98" firstAttribute="top" secondItem="426" secondAttribute="bottom" constant="10" id="AKy-wr-3Ad"/>
                                     <constraint firstItem="430" firstAttribute="leading" secondItem="95" secondAttribute="leading" id="C77-QG-Ofb"/>
                                     <constraint firstItem="93" firstAttribute="top" secondItem="338" secondAttribute="top" constant="19" id="D5J-pJ-w0H"/>
-                                    <constraint firstItem="430" firstAttribute="leading" secondItem="432" secondAttribute="trailing" constant="7" id="HQk-6c-c3o"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="GPy-18-xrB"/>
+                                    <constraint firstItem="430" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="432" secondAttribute="trailing" constant="8" symbolic="YES" id="HQk-6c-c3o"/>
                                     <constraint firstItem="103" firstAttribute="baseline" secondItem="104" secondAttribute="baseline" id="I0w-XP-Rqn"/>
                                     <constraint firstItem="104" firstAttribute="top" secondItem="98" secondAttribute="bottom" constant="10" id="IZ0-0E-38Q"/>
+                                    <constraint firstItem="99" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="Klx-p3-op3"/>
                                     <constraint firstItem="432" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="Mtp-BO-Mb0"/>
                                     <constraint firstAttribute="trailing" secondItem="430" secondAttribute="trailing" constant="22" id="Njn-4j-Xir"/>
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="ObC-W9-79u"/>
                                     <constraint firstItem="98" firstAttribute="trailing" secondItem="104" secondAttribute="trailing" id="QZr-nm-wWD"/>
+                                    <constraint firstItem="103" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="TP1-gs-TNa"/>
                                     <constraint firstItem="102" firstAttribute="trailing" secondItem="103" secondAttribute="trailing" id="VPr-PS-G3b"/>
                                     <constraint firstItem="95" firstAttribute="top" secondItem="430" secondAttribute="bottom" constant="20" id="aSg-1D-dTK"/>
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="426" secondAttribute="leading" id="fJa-rs-foZ"/>
                                     <constraint firstItem="428" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="fqO-Lt-pfp"/>
                                     <constraint firstItem="432" firstAttribute="baseline" secondItem="430" secondAttribute="baseline" id="hcJ-q7-fmJ"/>
+                                    <constraint firstItem="432" firstAttribute="leading" secondItem="338" secondAttribute="leading" constant="80" id="jvm-g9-bVs"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="426" secondAttribute="trailing" id="m1U-9L-zNF"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="428" secondAttribute="trailing" id="mpk-Rn-cRY"/>
                                     <constraint firstItem="430" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="25" id="nsu-Mq-rjL"/>
                                     <constraint firstItem="426" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="qLW-sY-iUw"/>
                                     <constraint firstItem="428" firstAttribute="baseline" secondItem="426" secondAttribute="baseline" id="ruQ-kH-On4"/>
+                                    <constraint firstItem="428" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="zMO-Gg-rnb"/>
                                 </constraints>
                             </view>
                         </tabViewItem>
                         <tabViewItem label="Дополнительно" identifier="2" id="336" userLabel="Advanced">
                             <view key="view" id="337" userLabel="Advanced">
-                                <rect key="frame" x="10" y="25" width="350" height="239"/>
+                                <rect key="frame" x="10" y="25" width="351" height="239"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="339">
                                         <rect key="frame" x="24" y="207" width="127" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Заменять «+» на «" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="346">
+                                        <buttonCell key="cell" type="check" title="Заменять «+» на «" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="346">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -286,7 +292,7 @@
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="347">
                                         <rect key="frame" x="24" y="92" width="170" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Соединяться через прокси" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" enabled="NO" inset="2" id="356">
+                                        <buttonCell key="cell" type="check" title="Соединяться через прокси" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="356">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -295,7 +301,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="348">
-                                        <rect key="frame" x="140" y="68" width="186" height="19"/>
+                                        <rect key="frame" x="140" y="68" width="187" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="355">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -311,7 +317,7 @@
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="349">
                                         <rect key="frame" x="140" y="41" width="43" height="19"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="43" id="TlP-zO-3o0"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="43" id="TlP-zO-3o0"/>
                                         </constraints>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="5060" drawsBackground="YES" id="354">
                                             <font key="font" metaFont="smallSystem"/>
@@ -344,7 +350,7 @@
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="395">
                                         <rect key="frame" x="209" y="177" width="36" height="19"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="36" id="e1t-sL-MCg"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="36" id="e1t-sL-MCg"/>
                                         </constraints>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="300" drawsBackground="YES" id="396">
                                             <font key="font" metaFont="smallSystem"/>
@@ -372,7 +378,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="96">
-                                        <rect key="frame" x="140" y="148" width="186" height="19"/>
+                                        <rect key="frame" x="140" y="148" width="187" height="19"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="113">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -386,7 +392,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="97">
-                                        <rect key="frame" x="140" y="119" width="186" height="19"/>
+                                        <rect key="frame" x="140" y="119" width="187" height="19"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="112">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -417,7 +423,7 @@
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="eo2-Ed-G06">
                                         <rect key="frame" x="24" y="14" width="132" height="18"/>
-                                        <buttonCell key="cell" type="check" title="Обновлять IP-адрес" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="gW3-9r-bYQ">
+                                        <buttonCell key="cell" type="check" title="Обновлять IP-адрес" bezelStyle="regularSquare" imagePosition="left" controlSize="small" inset="2" id="gW3-9r-bYQ">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
                                         </buttonCell>
@@ -431,11 +437,16 @@
                                     <constraint firstItem="96" firstAttribute="top" secondItem="395" secondAttribute="bottom" constant="10" id="3p8-Wf-8y9"/>
                                     <constraint firstItem="350" firstAttribute="trailing" secondItem="351" secondAttribute="trailing" id="4Sp-FL-yOI"/>
                                     <constraint firstItem="101" firstAttribute="trailing" secondItem="350" secondAttribute="trailing" id="5XB-hf-ncl"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="eo2-Ed-G06" secondAttribute="trailing" constant="20" symbolic="YES" id="6wT-A2-Zii"/>
+                                    <constraint firstItem="351" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="7D3-fN-oZs"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="140" id="7lX-Nr-ULt"/>
                                     <constraint firstItem="eRv-wi-Jsp" firstAttribute="leading" secondItem="340" secondAttribute="trailing" id="7m7-go-1fS"/>
+                                    <constraint firstItem="350" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="8Kf-xY-sD7"/>
                                     <constraint firstItem="395" firstAttribute="leading" secondItem="397" secondAttribute="trailing" constant="3" id="DTT-Yd-ZZT"/>
                                     <constraint firstItem="351" firstAttribute="baseline" secondItem="349" secondAttribute="baseline" id="IME-ZC-RR7"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="eRv-wi-Jsp" secondAttribute="trailing" constant="20" symbolic="YES" id="IkV-AZ-7mW"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="24" id="K5f-yM-Us9"/>
+                                    <constraint firstAttribute="trailing" secondItem="349" secondAttribute="trailing" priority="750" constant="168" id="KVW-PJ-SLK"/>
                                     <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="Kxb-ua-svC"/>
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="347" secondAttribute="leading" id="M24-Sx-3fa"/>
                                     <constraint firstItem="340" firstAttribute="leading" secondItem="339" secondAttribute="trailing" id="M6b-8g-OvD"/>
@@ -443,22 +454,28 @@
                                     <constraint firstItem="399" firstAttribute="baseline" secondItem="397" secondAttribute="baseline" id="OPr-qd-Gth"/>
                                     <constraint firstItem="349" firstAttribute="top" secondItem="348" secondAttribute="bottom" constant="8" symbolic="YES" id="OUH-Sa-eDu"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="100" secondAttribute="trailing" constant="7" id="PkT-fV-nP1"/>
+                                    <constraint firstAttribute="trailing" secondItem="399" secondAttribute="trailing" priority="750" constant="64" id="S8j-cf-hHk"/>
                                     <constraint firstItem="97" firstAttribute="leading" secondItem="348" secondAttribute="leading" id="Y1Z-NE-JIC"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="Y6F-KW-7Ff"/>
+                                    <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="Yxl-9Z-Vew"/>
                                     <constraint firstItem="340" firstAttribute="baseline" secondItem="339" secondAttribute="baseline" id="bEI-OX-62Q"/>
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="27" id="bbM-qQ-Svr"/>
                                     <constraint firstItem="340" firstAttribute="top" secondItem="337" secondAttribute="top" constant="14" id="blw-xd-2WF"/>
                                     <constraint firstItem="eRv-wi-Jsp" firstAttribute="baseline" secondItem="339" secondAttribute="baseline" id="cKH-um-2OR"/>
                                     <constraint firstItem="350" firstAttribute="baseline" secondItem="348" secondAttribute="baseline" id="cvF-n2-TgX"/>
                                     <constraint firstItem="96" firstAttribute="trailing" secondItem="97" secondAttribute="trailing" id="fnl-hB-D6b"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="349" secondAttribute="trailing" constant="20" symbolic="YES" id="g7g-wd-kv1"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="399" secondAttribute="trailing" constant="20" symbolic="YES" id="im8-JC-AWW"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="97" secondAttribute="leading" id="jJd-At-0ct"/>
                                     <constraint firstItem="399" firstAttribute="leading" secondItem="395" secondAttribute="trailing" constant="3" id="oAe-6B-eNx"/>
                                     <constraint firstItem="348" firstAttribute="leading" secondItem="349" secondAttribute="leading" id="q9R-qm-i6k"/>
                                     <constraint firstItem="397" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="26" id="rTN-X7-ef7"/>
                                     <constraint firstItem="eo2-Ed-G06" firstAttribute="top" secondItem="349" secondAttribute="bottom" constant="12" id="wmF-hQ-uRb"/>
                                     <constraint firstItem="97" firstAttribute="trailing" secondItem="348" secondAttribute="trailing" id="wqD-Md-5F4"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="347" secondAttribute="trailing" constant="20" symbolic="YES" id="xdv-iQ-bVS"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" symbolic="YES" id="ygR-RC-QCL"/>
                                     <constraint firstItem="101" firstAttribute="baseline" secondItem="97" secondAttribute="baseline" id="zam-uF-El3"/>
+                                    <constraint firstItem="101" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="15" id="zlt-cT-xDN"/>
                                 </constraints>
                             </view>
                         </tabViewItem>
@@ -468,7 +485,7 @@
                     <rect key="frame" x="20" y="19" width="23" height="23"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="21" id="Inu-ek-6Wp"/>
-                        <constraint firstAttribute="width" constant="23" id="iFC-2B-XeI"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="23" id="iFC-2B-XeI"/>
                     </constraints>
                     <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="119">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -489,8 +506,8 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="446" userLabel="Cant Edit Account">
-                    <rect key="frame" x="181" y="23" width="323" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Нельзя настраивать аккаунт во время его использования." id="447">
+                    <rect key="frame" x="162" y="23" width="361" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Нельзя настраивать аккаунт во время его использования." id="447">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -499,6 +516,7 @@
             </subviews>
             <constraints>
                 <constraint firstItem="79" firstAttribute="bottom" secondItem="334" secondAttribute="bottom" id="BJ6-Wm-bH2"/>
+                <constraint firstItem="79" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="120" secondAttribute="trailing" id="KFt-P5-iol"/>
                 <constraint firstItem="120" firstAttribute="height" secondItem="118" secondAttribute="height" id="LWk-LD-n8B"/>
                 <constraint firstItem="79" firstAttribute="top" secondItem="148" secondAttribute="top" constant="14" id="Pld-Wd-QNX"/>
                 <constraint firstItem="120" firstAttribute="width" secondItem="118" secondAttribute="width" id="Q9G-Vo-xdp"/>
@@ -512,7 +530,8 @@
                 <constraint firstItem="120" firstAttribute="leading" secondItem="118" secondAttribute="trailing" constant="-1" id="efs-z1-qym"/>
                 <constraint firstItem="79" firstAttribute="leading" secondItem="148" secondAttribute="leading" constant="20" symbolic="YES" id="eok-nk-bhG"/>
                 <constraint firstItem="118" firstAttribute="top" secondItem="79" secondAttribute="bottom" constant="8" symbolic="YES" id="ilZ-7h-wTd"/>
-                <constraint firstItem="446" firstAttribute="centerX" secondItem="334" secondAttribute="centerX" id="xvm-K2-sVa"/>
+                <constraint firstItem="446" firstAttribute="trailing" secondItem="334" secondAttribute="trailing" id="jpA-2X-hG8"/>
+                <constraint firstItem="446" firstAttribute="leading" secondItem="334" secondAttribute="leading" id="uIc-LB-QMV"/>
             </constraints>
             <point key="canvasLocation" x="139" y="154"/>
         </customView>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -18,6 +18,7 @@
                 <outlet property="fullNameField" destination="95" id="409"/>
                 <outlet property="passwordField" destination="104" id="413"/>
                 <outlet property="plusCharacterSubstitutionField" destination="340" id="415"/>
+                <outlet property="plusCharacterSubstitutionLabel" destination="eRv-wi-Jsp" id="gft-iH-wUx"/>
                 <outlet property="proxyHostField" destination="348" id="416"/>
                 <outlet property="proxyPortField" destination="349" id="417"/>
                 <outlet property="registrarField" destination="97" id="411"/>
@@ -90,11 +91,11 @@
                     <tabViewItems>
                         <tabViewItem label="Информация" identifier="1" id="335" userLabel="Account Information">
                             <view key="view" id="338" userLabel="Account Information">
-                                <rect key="frame" x="10" y="25" width="350" height="271"/>
+                                <rect key="frame" x="10" y="29" width="350" height="267"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                                        <rect key="frame" x="14" y="226" width="99" height="18"/>
+                                        <rect key="frame" x="14" y="222" width="99" height="18"/>
                                         <buttonCell key="cell" type="check" title="Использовать" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="94">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="smallSystem"/>
@@ -104,7 +105,7 @@
                                         </connections>
                                     </button>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                                        <rect key="frame" x="125" y="135" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="131" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="114">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +119,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                                        <rect key="frame" x="125" y="77" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="73" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="111">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,7 +133,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="99">
-                                        <rect key="frame" x="21" y="138" width="99" height="14"/>
+                                        <rect key="frame" x="21" y="134" width="99" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Имя с фамилией:" id="110">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +141,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="102">
-                                        <rect key="frame" x="37" y="80" width="83" height="14"/>
+                                        <rect key="frame" x="37" y="76" width="83" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пользователь:" id="107">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -148,7 +149,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="103">
-                                        <rect key="frame" x="72" y="51" width="48" height="14"/>
+                                        <rect key="frame" x="72" y="47" width="48" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Пароль:" id="106">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -156,7 +157,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="104">
-                                        <rect key="frame" x="125" y="48" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="44" width="185" height="19"/>
                                         <secureTextFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="105">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,7 +171,7 @@
                                         </connections>
                                     </secureTextField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="426">
-                                        <rect key="frame" x="125" y="106" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="102" width="185" height="19"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="427">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -184,7 +185,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="428">
-                                        <rect key="frame" x="76" y="109" width="44" height="14"/>
+                                        <rect key="frame" x="76" y="105" width="44" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Домен:" id="429">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -192,7 +193,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="430">
-                                        <rect key="frame" x="125" y="174" width="185" height="19"/>
+                                        <rect key="frame" x="125" y="170" width="185" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="185" id="NpR-uH-HqX"/>
                                         </constraints>
@@ -206,7 +207,7 @@
                                         </connections>
                                     </textField>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="432">
-                                        <rect key="frame" x="60" y="177" width="60" height="14"/>
+                                        <rect key="frame" x="60" y="173" width="60" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Название:" id="433">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
Due to the imperfection of the SIP protocol, a SIP soft phone has hard times choosing a proper IP address to include in SIP and SDP. This problem is often solved on the server by configuring it to ignore the IP addresses included by a phone in SIP and SDP and using the IP address from the IP headers instead, sending the SIP replies and audio to the IP address the requests came from, not the ones in SIP and SDP.

However, in practice a lot of servers are not configured in such smart way, which often causes one-way audio problems when people use VPNs  or several networks on their computers.

Telephone already had an “Update Contact and Via headers” checkbox that, when enabled, would update the IP address in SIP headers. The IP address to update is taken from the server responses. But that would not solve the one-way audio problem because SDP was not affected by this option.

The same checkbox is now named “Update IP address” and also updates the IP address in SDP. For backward compatibility, the existing configurations are not affected, and if they had this checkbox set before, the current state is mixed. When the checkbox shows the checked state, it now means that the IP address is updated in both SIP (as before) and SDP.

Closes #453 #538 