### PR TITLE
Last instead of first baseline

### DIFF
--- a/Telephone/Base.lproj/AccountPreferencesView.xib
+++ b/Telephone/Base.lproj/AccountPreferencesView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -223,12 +223,12 @@
                                 <constraints>
                                     <constraint firstItem="530" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="0zA-ra-Hpb"/>
                                     <constraint firstItem="534" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="42" id="1C0-TX-VdZ"/>
-                                    <constraint firstItem="104" firstAttribute="firstBaseline" secondItem="103" secondAttribute="firstBaseline" id="44B-8S-6lE"/>
+                                    <constraint firstItem="104" firstAttribute="baseline" secondItem="103" secondAttribute="baseline" id="44B-8S-6lE"/>
                                     <constraint firstItem="102" firstAttribute="trailing" secondItem="103" secondAttribute="trailing" id="83K-yj-YHs"/>
                                     <constraint firstItem="93" firstAttribute="leading" secondItem="413" secondAttribute="leading" constant="17" id="8in-eP-WoJ"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="530" secondAttribute="trailing" id="9Uv-NW-B53"/>
-                                    <constraint firstItem="536" firstAttribute="firstBaseline" secondItem="534" secondAttribute="firstBaseline" id="EDF-kG-izV"/>
-                                    <constraint firstItem="98" firstAttribute="firstBaseline" secondItem="102" secondAttribute="firstBaseline" id="F03-ck-yje"/>
+                                    <constraint firstItem="536" firstAttribute="baseline" secondItem="534" secondAttribute="baseline" id="EDF-kG-izV"/>
+                                    <constraint firstItem="98" firstAttribute="baseline" secondItem="102" secondAttribute="baseline" id="F03-ck-yje"/>
                                     <constraint firstItem="528" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="GtG-ZP-Jdj"/>
                                     <constraint firstItem="536" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="KRK-Ac-tk7"/>
                                     <constraint firstItem="536" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="Lkb-YC-DQ2"/>
@@ -240,7 +240,7 @@
                                     <constraint firstAttribute="trailing" secondItem="534" secondAttribute="trailing" constant="32" id="WAf-X4-LdX"/>
                                     <constraint firstItem="534" firstAttribute="leading" secondItem="536" secondAttribute="trailing" constant="7" id="ajg-yi-dBJ"/>
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="av8-w1-KMb"/>
-                                    <constraint firstItem="95" firstAttribute="firstBaseline" secondItem="99" secondAttribute="firstBaseline" id="cDS-9v-SZG"/>
+                                    <constraint firstItem="95" firstAttribute="baseline" secondItem="99" secondAttribute="baseline" id="cDS-9v-SZG"/>
                                     <constraint firstItem="528" firstAttribute="trailing" secondItem="98" secondAttribute="trailing" id="dHa-J4-8XH"/>
                                     <constraint firstItem="534" firstAttribute="trailing" secondItem="95" secondAttribute="trailing" id="ePv-sQ-PmP"/>
                                     <constraint firstItem="534" firstAttribute="leading" secondItem="95" secondAttribute="leading" id="fWo-cu-0xd"/>
@@ -248,7 +248,7 @@
                                     <constraint firstItem="530" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="413" secondAttribute="leading" constant="20" symbolic="YES" id="hoG-Aa-SnS"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="528" secondAttribute="trailing" id="kmb-5M-JuA"/>
                                     <constraint firstItem="95" firstAttribute="top" secondItem="534" secondAttribute="bottom" constant="20" id="lQa-aA-v6D"/>
-                                    <constraint firstItem="528" firstAttribute="firstBaseline" secondItem="530" secondAttribute="firstBaseline" id="lVJ-cB-X5V"/>
+                                    <constraint firstItem="528" firstAttribute="baseline" secondItem="530" secondAttribute="baseline" id="lVJ-cB-X5V"/>
                                     <constraint firstItem="98" firstAttribute="top" secondItem="528" secondAttribute="bottom" constant="10" id="qOe-cA-aI0"/>
                                     <constraint firstItem="93" firstAttribute="top" secondItem="413" secondAttribute="top" constant="36" id="rvX-9Z-2g6"/>
                                     <constraint firstItem="104" firstAttribute="top" secondItem="98" secondAttribute="bottom" constant="10" id="scl-ka-DzA"/>
@@ -414,7 +414,7 @@
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xf9-ce-jif" secondAttribute="trailing" constant="20" symbolic="YES" id="6Gv-7k-BhO"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4L8-E6-lKd" secondAttribute="trailing" constant="20" symbolic="YES" id="8h4-mc-M2g"/>
                                     <constraint firstItem="gHr-pY-4ah" firstAttribute="leading" secondItem="Ify-XP-VVA" secondAttribute="leading" id="9tf-dO-we4"/>
-                                    <constraint firstItem="pfR-7Z-E7H" firstAttribute="firstBaseline" secondItem="dli-GZ-E5f" secondAttribute="firstBaseline" id="9w1-dt-zjD"/>
+                                    <constraint firstItem="pfR-7Z-E7H" firstAttribute="baseline" secondItem="dli-GZ-E5f" secondAttribute="baseline" id="9w1-dt-zjD"/>
                                     <constraint firstItem="4L8-E6-lKd" firstAttribute="top" secondItem="INe-5P-bRu" secondAttribute="bottom" constant="20" id="AX1-Bk-a9B"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ngD-ji-goI" secondAttribute="trailing" constant="20" symbolic="YES" id="AXU-bM-Vye"/>
                                     <constraint firstAttribute="trailing" secondItem="1UL-lr-59v" secondAttribute="trailing" constant="18" id="B7v-MJ-Nrl"/>
@@ -427,11 +427,11 @@
                                     <constraint firstAttribute="trailing" secondItem="dli-GZ-E5f" secondAttribute="trailing" priority="750" constant="160" id="JmM-eT-UxV"/>
                                     <constraint firstItem="Ify-XP-VVA" firstAttribute="leading" secondItem="iBU-Gy-PuJ" secondAttribute="leading" id="K8R-zS-jfP"/>
                                     <constraint firstItem="ngD-ji-goI" firstAttribute="leading" secondItem="XxC-OI-tYb" secondAttribute="leading" constant="35" id="KO2-VX-VyP"/>
-                                    <constraint firstItem="iBU-Gy-PuJ" firstAttribute="firstBaseline" secondItem="2I5-wK-O3x" secondAttribute="firstBaseline" id="Kdn-kJ-rrd"/>
+                                    <constraint firstItem="iBU-Gy-PuJ" firstAttribute="baseline" secondItem="2I5-wK-O3x" secondAttribute="baseline" id="Kdn-kJ-rrd"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iBU-Gy-PuJ" secondAttribute="trailing" constant="20" symbolic="YES" id="P6y-3d-Eab"/>
                                     <constraint firstItem="1UL-lr-59v" firstAttribute="top" secondItem="ngD-ji-goI" secondAttribute="bottom" constant="8" id="Pon-nf-7Fc"/>
                                     <constraint firstItem="1UL-lr-59v" firstAttribute="leading" secondItem="XxC-OI-tYb" secondAttribute="leading" constant="115" id="QGj-cE-1wk"/>
-                                    <constraint firstItem="ho6-cH-aLd" firstAttribute="firstBaseline" secondItem="1UL-lr-59v" secondAttribute="firstBaseline" id="RVD-q2-LV8"/>
+                                    <constraint firstItem="ho6-cH-aLd" firstAttribute="baseline" secondItem="1UL-lr-59v" secondAttribute="baseline" id="RVD-q2-LV8"/>
                                     <constraint firstItem="uyP-rU-EtH" firstAttribute="top" secondItem="4L8-E6-lKd" secondAttribute="bottom" constant="8" id="UnR-2l-9xZ"/>
                                     <constraint firstItem="2I5-wK-O3x" firstAttribute="trailing" secondItem="pfR-7Z-E7H" secondAttribute="trailing" id="VQe-X1-tH6"/>
                                     <constraint firstItem="iBU-Gy-PuJ" firstAttribute="top" secondItem="dli-GZ-E5f" secondAttribute="bottom" constant="20" id="WMg-2O-h76"/>
@@ -447,7 +447,7 @@
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="uyP-rU-EtH" secondAttribute="trailing" constant="20" symbolic="YES" id="pvl-ms-1JM"/>
                                     <constraint firstItem="iBU-Gy-PuJ" firstAttribute="leading" secondItem="dli-GZ-E5f" secondAttribute="leading" id="rC2-2X-nui"/>
                                     <constraint firstItem="INe-5P-bRu" firstAttribute="leading" secondItem="xf9-ce-jif" secondAttribute="leading" id="urg-AP-1t2"/>
-                                    <constraint firstItem="xf9-ce-jif" firstAttribute="firstBaseline" secondItem="Miv-Fk-KKm" secondAttribute="firstBaseline" id="w0h-rF-uHU"/>
+                                    <constraint firstItem="xf9-ce-jif" firstAttribute="baseline" secondItem="Miv-Fk-KKm" secondAttribute="baseline" id="w0h-rF-uHU"/>
                                     <constraint firstItem="INe-5P-bRu" firstAttribute="leading" secondItem="xf9-ce-jif" secondAttribute="leading" id="w1d-ZW-uta"/>
                                     <constraint firstItem="Miv-Fk-KKm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="XxC-OI-tYb" secondAttribute="leading" constant="20" symbolic="YES" id="wGv-bh-Fi5"/>
                                     <constraint firstItem="Ify-XP-VVA" firstAttribute="top" secondItem="iBU-Gy-PuJ" secondAttribute="bottom" constant="8" id="wSe-Bb-U8x"/>
@@ -573,16 +573,16 @@
                                     </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="100" firstAttribute="firstBaseline" secondItem="96" secondAttribute="firstBaseline" id="05d-gK-lgS"/>
+                                    <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="05d-gK-lgS"/>
                                     <constraint firstItem="499" firstAttribute="top" secondItem="418" secondAttribute="bottom" constant="10" id="0Pl-Zw-7Ev"/>
                                     <constraint firstItem="418" firstAttribute="leading" secondItem="416" secondAttribute="trailing" id="4Tg-Wa-cia"/>
                                     <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="20" symbolic="YES" id="4mW-34-Ub8"/>
-                                    <constraint firstItem="ERB-3b-3jA" firstAttribute="firstBaseline" secondItem="418" secondAttribute="firstBaseline" id="Bws-00-BCL"/>
+                                    <constraint firstItem="ERB-3b-3jA" firstAttribute="baseline" secondItem="418" secondAttribute="baseline" id="Bws-00-BCL"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="18" id="CbD-vu-2pv"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="97" secondAttribute="leading" id="DKL-g2-ELY"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="501" secondAttribute="trailing" constant="20" symbolic="YES" id="H6r-la-wDh"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="I0z-8G-6f0"/>
-                                    <constraint firstItem="497" firstAttribute="firstBaseline" secondItem="499" secondAttribute="firstBaseline" id="J73-ry-Wam"/>
+                                    <constraint firstItem="497" firstAttribute="baseline" secondItem="499" secondAttribute="baseline" id="J73-ry-Wam"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="499" secondAttribute="bottom" constant="10" id="KjC-p2-9ji"/>
                                     <constraint firstItem="499" firstAttribute="leading" secondItem="497" secondAttribute="trailing" constant="7" id="NE6-BV-leQ"/>
                                     <constraint firstItem="497" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="412" secondAttribute="leading" constant="19" id="NVO-ft-eEw"/>
@@ -590,11 +590,11 @@
                                     <constraint firstItem="499" firstAttribute="leading" secondItem="412" secondAttribute="leading" constant="115" id="Qcx-L6-KTr"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" id="SaI-ao-4Gp"/>
                                     <constraint firstItem="418" firstAttribute="leading" secondItem="499" secondAttribute="leading" id="Ut6-J2-loF"/>
-                                    <constraint firstItem="101" firstAttribute="firstBaseline" secondItem="97" secondAttribute="firstBaseline" id="ZEV-Of-3eP"/>
+                                    <constraint firstItem="101" firstAttribute="baseline" secondItem="97" secondAttribute="baseline" id="ZEV-Of-3eP"/>
                                     <constraint firstItem="497" firstAttribute="baseline" secondItem="501" secondAttribute="baseline" id="b95-3g-uOj"/>
                                     <constraint firstItem="418" firstAttribute="top" secondItem="412" secondAttribute="top" constant="14" id="beP-Nm-QTW"/>
                                     <constraint firstItem="416" firstAttribute="leading" secondItem="412" secondAttribute="leading" constant="35" id="dVU-rd-5Bp"/>
-                                    <constraint firstItem="418" firstAttribute="firstBaseline" secondItem="416" secondAttribute="firstBaseline" id="e1f-0e-Vv3"/>
+                                    <constraint firstItem="418" firstAttribute="baseline" secondItem="416" secondAttribute="baseline" id="e1f-0e-Vv3"/>
                                     <constraint firstItem="501" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="499" secondAttribute="trailing" constant="3" id="hGQ-If-5fh"/>
                                     <constraint firstItem="ERB-3b-3jA" firstAttribute="leading" secondItem="418" secondAttribute="trailing" id="hNh-Ab-Dl7"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ERB-3b-3jA" secondAttribute="trailing" constant="20" symbolic="YES" id="hTE-qI-LXB"/>

--- a/Telephone/Base.lproj/NetworkPreferencesView.xib
+++ b/Telephone/Base.lproj/NetworkPreferencesView.xib
@@ -177,7 +177,7 @@
                 <constraint firstItem="482" firstAttribute="leading" secondItem="484" secondAttribute="trailing" constant="6" id="36G-f4-Brl"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="549" secondAttribute="trailing" constant="20" symbolic="YES" id="4un-0L-zfg"/>
                 <constraint firstItem="466" firstAttribute="leading" secondItem="482" secondAttribute="leading" id="5Rn-Z6-tFr"/>
-                <constraint firstItem="198" firstAttribute="firstBaseline" secondItem="196" secondAttribute="firstBaseline" id="6VS-Ri-uIw"/>
+                <constraint firstItem="198" firstAttribute="baseline" secondItem="196" secondAttribute="baseline" id="6VS-Ri-uIw"/>
                 <constraint firstItem="315" firstAttribute="width" secondItem="192" secondAttribute="width" id="9hy-za-Gu6"/>
                 <constraint firstItem="319" firstAttribute="leading" secondItem="482" secondAttribute="leading" id="CeI-ct-4UM"/>
                 <constraint firstItem="549" firstAttribute="leading" secondItem="482" secondAttribute="leading" id="DHw-o3-3tL"/>
@@ -194,12 +194,12 @@
                 <constraint firstItem="194" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="260" secondAttribute="leading" constant="20" symbolic="YES" id="X70-cx-yst"/>
                 <constraint firstItem="315" firstAttribute="top" secondItem="549" secondAttribute="bottom" constant="20" id="Y2q-TU-52I"/>
                 <constraint firstItem="319" firstAttribute="width" secondItem="482" secondAttribute="width" id="Yig-HR-XyX"/>
-                <constraint firstItem="484" firstAttribute="firstBaseline" secondItem="482" secondAttribute="firstBaseline" id="ZGF-tC-gnB"/>
+                <constraint firstItem="484" firstAttribute="baseline" secondItem="482" secondAttribute="baseline" id="ZGF-tC-gnB"/>
                 <constraint firstItem="194" firstAttribute="trailing" secondItem="484" secondAttribute="trailing" id="crz-kz-RgV"/>
                 <constraint firstItem="Zlz-tb-psa" firstAttribute="top" secondItem="319" secondAttribute="bottom" constant="8" id="d0c-dz-6XZ"/>
                 <constraint firstItem="319" firstAttribute="top" secondItem="315" secondAttribute="bottom" constant="8" id="dLs-jq-MRj"/>
                 <constraint firstItem="466" firstAttribute="top" secondItem="196" secondAttribute="bottom" constant="14" id="fye-QJ-b91"/>
-                <constraint firstItem="317" firstAttribute="firstBaseline" secondItem="315" secondAttribute="firstBaseline" id="gFl-BH-2cD"/>
+                <constraint firstItem="317" firstAttribute="baseline" secondItem="315" secondAttribute="baseline" id="gFl-BH-2cD"/>
                 <constraint firstItem="549" firstAttribute="top" secondItem="466" secondAttribute="bottom" constant="6" id="gb2-Bg-aAL"/>
                 <constraint firstItem="196" firstAttribute="trailing" secondItem="482" secondAttribute="trailing" id="gpy-Lj-pvX"/>
                 <constraint firstItem="491" firstAttribute="leading" secondItem="482" secondAttribute="leading" id="hYp-vX-6V0"/>
@@ -213,10 +213,10 @@
                 <constraint firstItem="491" firstAttribute="trailing" secondItem="192" secondAttribute="trailing" constant="20" id="sDt-6c-QMy"/>
                 <constraint firstAttribute="bottom" secondItem="Zlz-tb-psa" secondAttribute="bottom" constant="20" id="sJA-8G-G5m"/>
                 <constraint firstItem="198" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="260" secondAttribute="leading" constant="20" symbolic="YES" id="u7p-SO-Epx"/>
-                <constraint firstItem="320" firstAttribute="firstBaseline" secondItem="319" secondAttribute="firstBaseline" id="waj-wh-Wyw"/>
+                <constraint firstItem="320" firstAttribute="baseline" secondItem="319" secondAttribute="baseline" id="waj-wh-Wyw"/>
                 <constraint firstItem="196" firstAttribute="top" secondItem="192" secondAttribute="bottom" constant="8" id="wha-Gc-87G"/>
                 <constraint firstItem="484" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="260" secondAttribute="leading" constant="20" symbolic="YES" id="wok-pY-9Y9"/>
-                <constraint firstItem="194" firstAttribute="firstBaseline" secondItem="192" secondAttribute="firstBaseline" id="yZh-0K-jhV"/>
+                <constraint firstItem="194" firstAttribute="baseline" secondItem="192" secondAttribute="baseline" id="yZh-0K-jhV"/>
                 <constraint firstItem="192" firstAttribute="top" secondItem="491" secondAttribute="bottom" constant="14" id="yqv-1k-dtG"/>
                 <constraint firstItem="317" firstAttribute="trailing" secondItem="484" secondAttribute="trailing" id="zsj-Ix-VOj"/>
                 <constraint firstItem="9cR-ug-aVH" firstAttribute="centerY" secondItem="315" secondAttribute="centerY" id="zt5-vD-YJD"/>

--- a/Telephone/de.lproj/AccountPreferencesView.xib
+++ b/Telephone/de.lproj/AccountPreferencesView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -221,7 +221,7 @@
                                     </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="99" firstAttribute="firstBaseline" secondItem="95" secondAttribute="firstBaseline" id="1TI-v6-bt4"/>
+                                    <constraint firstItem="99" firstAttribute="baseline" secondItem="95" secondAttribute="baseline" id="1TI-v6-bt4"/>
                                     <constraint firstItem="98" firstAttribute="trailing" secondItem="104" secondAttribute="trailing" id="3GJ-Ai-1S5"/>
                                     <constraint firstItem="95" firstAttribute="top" secondItem="427" secondAttribute="bottom" constant="20" id="6gL-fy-arY"/>
                                     <constraint firstAttribute="trailing" secondItem="427" secondAttribute="trailing" constant="32" id="A5V-vc-rfr"/>
@@ -233,7 +233,7 @@
                                     <constraint firstItem="93" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="17" id="LME-dB-19E"/>
                                     <constraint firstItem="98" firstAttribute="top" secondItem="423" secondAttribute="bottom" constant="10" id="NdF-kg-d5P"/>
                                     <constraint firstItem="102" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="OSs-CK-PNy"/>
-                                    <constraint firstItem="427" firstAttribute="firstBaseline" secondItem="429" secondAttribute="firstBaseline" id="S0K-Bc-HK4"/>
+                                    <constraint firstItem="427" firstAttribute="baseline" secondItem="429" secondAttribute="baseline" id="S0K-Bc-HK4"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="T3e-TK-P4I"/>
                                     <constraint firstItem="99" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="Tp7-Nr-nbi"/>
                                     <constraint firstItem="429" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="YLg-6V-Q2m"/>
@@ -241,10 +241,10 @@
                                     <constraint firstItem="98" firstAttribute="leading" secondItem="104" secondAttribute="leading" id="aaA-nz-2dJ"/>
                                     <constraint firstItem="427" firstAttribute="leading" secondItem="95" secondAttribute="leading" id="cE7-2F-30v"/>
                                     <constraint firstItem="102" firstAttribute="trailing" secondItem="103" secondAttribute="trailing" id="dSw-dz-1nU"/>
-                                    <constraint firstItem="103" firstAttribute="firstBaseline" secondItem="104" secondAttribute="firstBaseline" id="fRO-e4-Gp8"/>
-                                    <constraint firstItem="102" firstAttribute="firstBaseline" secondItem="98" secondAttribute="firstBaseline" id="fWl-9k-rgQ"/>
+                                    <constraint firstItem="103" firstAttribute="baseline" secondItem="104" secondAttribute="baseline" id="fRO-e4-Gp8"/>
+                                    <constraint firstItem="102" firstAttribute="baseline" secondItem="98" secondAttribute="baseline" id="fWl-9k-rgQ"/>
                                     <constraint firstItem="429" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="ftu-A1-445"/>
-                                    <constraint firstItem="425" firstAttribute="firstBaseline" secondItem="423" secondAttribute="firstBaseline" id="gK6-9S-fd6"/>
+                                    <constraint firstItem="425" firstAttribute="baseline" secondItem="423" secondAttribute="baseline" id="gK6-9S-fd6"/>
                                     <constraint firstItem="423" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="hTT-wV-6PY"/>
                                     <constraint firstItem="423" firstAttribute="top" secondItem="95" secondAttribute="bottom" constant="10" id="hXu-g8-tyF"/>
                                     <constraint firstItem="425" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="iju-YX-Ydm"/>
@@ -418,7 +418,7 @@
                                     <constraint firstItem="KwF-8i-YYT" firstAttribute="top" secondItem="qlr-bg-Q9S" secondAttribute="bottom" constant="8" id="7bK-I3-feI"/>
                                     <constraint firstItem="vy7-VC-BYE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="v0A-hJ-bHE" secondAttribute="leading" constant="20" symbolic="YES" id="8bD-nS-Q6i"/>
                                     <constraint firstItem="Zhz-iB-eXi" firstAttribute="top" secondItem="ASv-CD-ZyY" secondAttribute="bottom" constant="8" id="8z7-49-bbe"/>
-                                    <constraint firstItem="Vzo-HL-BXw" firstAttribute="firstBaseline" secondItem="vy7-VC-BYE" secondAttribute="firstBaseline" id="Ap9-IO-G7T"/>
+                                    <constraint firstItem="Vzo-HL-BXw" firstAttribute="baseline" secondItem="vy7-VC-BYE" secondAttribute="baseline" id="Ap9-IO-G7T"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="vKZ-Iu-UL6" secondAttribute="trailing" constant="20" symbolic="YES" id="BRq-tL-PZD"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KwF-8i-YYT" secondAttribute="trailing" constant="20" symbolic="YES" id="DWk-1F-CAv"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ASv-CD-ZyY" secondAttribute="trailing" constant="20" symbolic="YES" id="DdG-MS-YAM"/>
@@ -434,9 +434,9 @@
                                     <constraint firstItem="Mxd-Zd-22o" firstAttribute="leading" secondItem="qlr-bg-Q9S" secondAttribute="leading" id="UAA-fj-amI"/>
                                     <constraint firstAttribute="trailing" secondItem="edH-Mz-B40" secondAttribute="trailing" constant="26" id="XXH-2A-f2a"/>
                                     <constraint firstItem="edH-Mz-B40" firstAttribute="leading" secondItem="ZZC-9u-xcr" secondAttribute="trailing" constant="7" id="bTe-et-JWy"/>
-                                    <constraint firstItem="ASv-CD-ZyY" firstAttribute="firstBaseline" secondItem="mr1-9A-aZN" secondAttribute="firstBaseline" id="bWc-Qx-cFL"/>
+                                    <constraint firstItem="ASv-CD-ZyY" firstAttribute="baseline" secondItem="mr1-9A-aZN" secondAttribute="baseline" id="bWc-Qx-cFL"/>
                                     <constraint firstItem="ASv-CD-ZyY" firstAttribute="leading" secondItem="vfx-km-Z7p" secondAttribute="leading" id="ba2-jA-oOq"/>
-                                    <constraint firstItem="ERB-jl-5dd" firstAttribute="firstBaseline" secondItem="fM0-sX-Ij9" secondAttribute="firstBaseline" id="hid-XJ-Soa"/>
+                                    <constraint firstItem="ERB-jl-5dd" firstAttribute="baseline" secondItem="fM0-sX-Ij9" secondAttribute="baseline" id="hid-XJ-Soa"/>
                                     <constraint firstItem="KwF-8i-YYT" firstAttribute="leading" secondItem="qlr-bg-Q9S" secondAttribute="leading" constant="17" id="ixx-aU-cLI"/>
                                     <constraint firstItem="fM0-sX-Ij9" firstAttribute="trailing" secondItem="vy7-VC-BYE" secondAttribute="trailing" id="jrf-61-747"/>
                                     <constraint firstItem="edH-Mz-B40" firstAttribute="top" secondItem="Mxd-Zd-22o" secondAttribute="bottom" constant="8" symbolic="YES" id="lvd-0i-xad"/>
@@ -450,7 +450,7 @@
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qlr-bg-Q9S" secondAttribute="trailing" constant="20" symbolic="YES" id="tVd-cq-JOL"/>
                                     <constraint firstItem="Vzo-HL-BXw" firstAttribute="leading" secondItem="ERB-jl-5dd" secondAttribute="leading" id="trY-3b-Ch5"/>
                                     <constraint firstItem="ZZC-9u-xcr" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="v0A-hJ-bHE" secondAttribute="leading" constant="20" symbolic="YES" id="vIZ-Bv-TI8"/>
-                                    <constraint firstItem="edH-Mz-B40" firstAttribute="firstBaseline" secondItem="ZZC-9u-xcr" secondAttribute="firstBaseline" id="xg0-fU-418"/>
+                                    <constraint firstItem="edH-Mz-B40" firstAttribute="baseline" secondItem="ZZC-9u-xcr" secondAttribute="baseline" id="xg0-fU-418"/>
                                     <constraint firstItem="mr1-9A-aZN" firstAttribute="trailing" secondItem="vy7-VC-BYE" secondAttribute="trailing" id="ype-l3-TyX"/>
                                 </constraints>
                             </view>
@@ -576,9 +576,9 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="339" firstAttribute="top" secondItem="336" secondAttribute="top" constant="14" id="09J-3N-ZaM"/>
-                                    <constraint firstItem="97" firstAttribute="firstBaseline" secondItem="101" secondAttribute="firstBaseline" id="2am-Ob-5T8"/>
+                                    <constraint firstItem="97" firstAttribute="baseline" secondItem="101" secondAttribute="baseline" id="2am-Ob-5T8"/>
                                     <constraint firstItem="96" firstAttribute="trailing" secondItem="97" secondAttribute="trailing" id="3cc-Y1-NhG"/>
-                                    <constraint firstItem="96" firstAttribute="firstBaseline" secondItem="100" secondAttribute="firstBaseline" id="6I9-WU-PyF"/>
+                                    <constraint firstItem="96" firstAttribute="baseline" secondItem="100" secondAttribute="baseline" id="6I9-WU-PyF"/>
                                     <constraint firstItem="oOE-ez-BHg" firstAttribute="leading" secondItem="339" secondAttribute="trailing" id="715-Jc-AYd"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oOE-ez-BHg" secondAttribute="trailing" constant="20" symbolic="YES" id="74Q-0A-DQ0"/>
                                     <constraint firstItem="oOE-ez-BHg" firstAttribute="baseline" secondItem="338" secondAttribute="baseline" id="7Uc-Te-zVW"/>

--- a/Telephone/ru.lproj/AccountPreferencesView.xib
+++ b/Telephone/ru.lproj/AccountPreferencesView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -221,8 +221,8 @@
                                     </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="99" firstAttribute="firstBaseline" secondItem="95" secondAttribute="firstBaseline" id="2FN-Yn-tXu"/>
-                                    <constraint firstItem="102" firstAttribute="firstBaseline" secondItem="98" secondAttribute="firstBaseline" id="2Kj-UO-fKD"/>
+                                    <constraint firstItem="99" firstAttribute="baseline" secondItem="95" secondAttribute="baseline" id="2FN-Yn-tXu"/>
+                                    <constraint firstItem="102" firstAttribute="baseline" secondItem="98" secondAttribute="baseline" id="2Kj-UO-fKD"/>
                                     <constraint firstItem="93" firstAttribute="leading" secondItem="338" secondAttribute="leading" constant="17" id="353-sD-1Gn"/>
                                     <constraint firstItem="426" firstAttribute="trailing" secondItem="98" secondAttribute="trailing" id="7PY-Np-Ecn"/>
                                     <constraint firstItem="430" firstAttribute="trailing" secondItem="95" secondAttribute="trailing" id="8WQ-7U-dSG"/>
@@ -233,7 +233,7 @@
                                     <constraint firstItem="93" firstAttribute="top" secondItem="338" secondAttribute="top" constant="36" id="D5J-pJ-w0H"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="93" secondAttribute="trailing" constant="20" symbolic="YES" id="GPy-18-xrB"/>
                                     <constraint firstItem="430" firstAttribute="leading" secondItem="432" secondAttribute="trailing" constant="7" id="HQk-6c-c3o"/>
-                                    <constraint firstItem="103" firstAttribute="firstBaseline" secondItem="104" secondAttribute="firstBaseline" id="I0w-XP-Rqn"/>
+                                    <constraint firstItem="103" firstAttribute="baseline" secondItem="104" secondAttribute="baseline" id="I0w-XP-Rqn"/>
                                     <constraint firstItem="104" firstAttribute="top" secondItem="98" secondAttribute="bottom" constant="10" id="IZ0-0E-38Q"/>
                                     <constraint firstItem="99" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="Klx-p3-op3"/>
                                     <constraint firstItem="432" firstAttribute="trailing" secondItem="99" secondAttribute="trailing" id="Mtp-BO-Mb0"/>
@@ -245,13 +245,13 @@
                                     <constraint firstItem="95" firstAttribute="top" secondItem="430" secondAttribute="bottom" constant="20" id="aSg-1D-dTK"/>
                                     <constraint firstItem="95" firstAttribute="leading" secondItem="426" secondAttribute="leading" id="fJa-rs-foZ"/>
                                     <constraint firstItem="428" firstAttribute="trailing" secondItem="102" secondAttribute="trailing" id="fqO-Lt-pfp"/>
-                                    <constraint firstItem="432" firstAttribute="firstBaseline" secondItem="430" secondAttribute="firstBaseline" id="hcJ-q7-fmJ"/>
+                                    <constraint firstItem="432" firstAttribute="baseline" secondItem="430" secondAttribute="baseline" id="hcJ-q7-fmJ"/>
                                     <constraint firstItem="432" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="jvm-g9-bVs"/>
                                     <constraint firstItem="95" firstAttribute="trailing" secondItem="426" secondAttribute="trailing" id="m1U-9L-zNF"/>
                                     <constraint firstItem="99" firstAttribute="trailing" secondItem="428" secondAttribute="trailing" id="mpk-Rn-cRY"/>
                                     <constraint firstItem="430" firstAttribute="top" secondItem="93" secondAttribute="bottom" constant="42" id="nsu-Mq-rjL"/>
                                     <constraint firstItem="426" firstAttribute="leading" secondItem="98" secondAttribute="leading" id="qLW-sY-iUw"/>
-                                    <constraint firstItem="428" firstAttribute="firstBaseline" secondItem="426" secondAttribute="firstBaseline" id="ruQ-kH-On4"/>
+                                    <constraint firstItem="428" firstAttribute="baseline" secondItem="426" secondAttribute="baseline" id="ruQ-kH-On4"/>
                                     <constraint firstItem="428" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="338" secondAttribute="leading" constant="20" symbolic="YES" id="zMO-Gg-rnb"/>
                                 </constraints>
                             </view>
@@ -432,9 +432,9 @@
                                     <constraint firstItem="N5T-Xw-x7u" firstAttribute="trailing" secondItem="If6-S0-mKW" secondAttribute="trailing" id="X91-Yv-div"/>
                                     <constraint firstItem="ygh-Uu-EPf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ski-R3-RoW" secondAttribute="leading" constant="20" symbolic="YES" id="Yqd-zF-eRb"/>
                                     <constraint firstItem="V37-Qr-Brx" firstAttribute="leading" secondItem="Zix-l7-dLP" secondAttribute="leading" id="ZOU-Nd-eYD"/>
-                                    <constraint firstItem="kb5-sC-s0Z" firstAttribute="firstBaseline" secondItem="ygh-Uu-EPf" secondAttribute="firstBaseline" id="bqq-DH-Nbc"/>
-                                    <constraint firstItem="eg8-ne-B5z" firstAttribute="firstBaseline" secondItem="YOf-xI-TUo" secondAttribute="firstBaseline" id="bug-c8-fbG"/>
-                                    <constraint firstItem="N5T-Xw-x7u" firstAttribute="firstBaseline" secondItem="V37-Qr-Brx" secondAttribute="firstBaseline" id="c5j-on-xpU"/>
+                                    <constraint firstItem="kb5-sC-s0Z" firstAttribute="baseline" secondItem="ygh-Uu-EPf" secondAttribute="baseline" id="bqq-DH-Nbc"/>
+                                    <constraint firstItem="eg8-ne-B5z" firstAttribute="baseline" secondItem="YOf-xI-TUo" secondAttribute="baseline" id="bug-c8-fbG"/>
+                                    <constraint firstItem="N5T-Xw-x7u" firstAttribute="baseline" secondItem="V37-Qr-Brx" secondAttribute="baseline" id="c5j-on-xpU"/>
                                     <constraint firstItem="kb5-sC-s0Z" firstAttribute="top" secondItem="5RV-gl-2uZ" secondAttribute="bottom" constant="20" id="d44-gf-dAc"/>
                                     <constraint firstItem="eg8-ne-B5z" firstAttribute="leading" secondItem="Zix-l7-dLP" secondAttribute="leading" id="dJX-wB-cTa"/>
                                     <constraint firstItem="If6-S0-mKW" firstAttribute="trailing" secondItem="YOf-xI-TUo" secondAttribute="trailing" id="dbr-gT-ohj"/>
@@ -445,7 +445,7 @@
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5RV-gl-2uZ" secondAttribute="trailing" constant="20" symbolic="YES" id="kod-VF-7h1"/>
                                     <constraint firstAttribute="trailing" secondItem="Zix-l7-dLP" secondAttribute="trailing" priority="750" constant="167" id="kvQ-c1-DII"/>
                                     <constraint firstItem="IR7-MQ-gNV" firstAttribute="top" secondItem="ski-R3-RoW" secondAttribute="top" constant="18" id="nbk-Ke-rrb"/>
-                                    <constraint firstItem="If6-S0-mKW" firstAttribute="firstBaseline" secondItem="Zix-l7-dLP" secondAttribute="firstBaseline" id="qYO-fy-CYW"/>
+                                    <constraint firstItem="If6-S0-mKW" firstAttribute="baseline" secondItem="Zix-l7-dLP" secondAttribute="baseline" id="qYO-fy-CYW"/>
                                     <constraint firstItem="eg8-ne-B5z" firstAttribute="top" secondItem="Zix-l7-dLP" secondAttribute="bottom" constant="20" id="rTD-om-Hrh"/>
                                     <constraint firstItem="5RV-gl-2uZ" firstAttribute="leading" secondItem="XEg-1K-4ec" secondAttribute="leading" id="t6D-Dv-RtT"/>
                                     <constraint firstItem="Zix-l7-dLP" firstAttribute="top" secondItem="V37-Qr-Brx" secondAttribute="bottom" constant="8" symbolic="YES" id="wGN-8j-l3S"/>
@@ -572,14 +572,14 @@
                                     </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="395" firstAttribute="firstBaseline" secondItem="397" secondAttribute="firstBaseline" id="2Rl-G1-NNS"/>
+                                    <constraint firstItem="395" firstAttribute="baseline" secondItem="397" secondAttribute="baseline" id="2Rl-G1-NNS"/>
                                     <constraint firstItem="96" firstAttribute="top" secondItem="395" secondAttribute="bottom" constant="10" id="3p8-Wf-8y9"/>
                                     <constraint firstItem="96" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="140" id="7lX-Nr-ULt"/>
                                     <constraint firstItem="eRv-wi-Jsp" firstAttribute="leading" secondItem="340" secondAttribute="trailing" id="7m7-go-1fS"/>
                                     <constraint firstItem="395" firstAttribute="leading" secondItem="397" secondAttribute="trailing" constant="3" id="DTT-Yd-ZZT"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="eRv-wi-Jsp" secondAttribute="trailing" constant="20" symbolic="YES" id="IkV-AZ-7mW"/>
                                     <constraint firstAttribute="trailing" secondItem="96" secondAttribute="trailing" constant="23" id="K5f-yM-Us9"/>
-                                    <constraint firstItem="100" firstAttribute="firstBaseline" secondItem="96" secondAttribute="firstBaseline" id="Kxb-ua-svC"/>
+                                    <constraint firstItem="100" firstAttribute="baseline" secondItem="96" secondAttribute="baseline" id="Kxb-ua-svC"/>
                                     <constraint firstItem="340" firstAttribute="leading" secondItem="339" secondAttribute="trailing" id="M6b-8g-OvD"/>
                                     <constraint firstItem="395" firstAttribute="top" secondItem="340" secondAttribute="bottom" constant="10" id="O9D-Ft-2do"/>
                                     <constraint firstItem="399" firstAttribute="baseline" secondItem="397" secondAttribute="baseline" id="OPr-qd-Gth"/>
@@ -587,7 +587,7 @@
                                     <constraint firstAttribute="trailing" secondItem="399" secondAttribute="trailing" priority="750" constant="63" id="S8j-cf-hHk"/>
                                     <constraint firstItem="100" firstAttribute="trailing" secondItem="101" secondAttribute="trailing" id="Y6F-KW-7Ff"/>
                                     <constraint firstItem="100" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="20" symbolic="YES" id="Yxl-9Z-Vew"/>
-                                    <constraint firstItem="340" firstAttribute="firstBaseline" secondItem="339" secondAttribute="firstBaseline" id="bEI-OX-62Q"/>
+                                    <constraint firstItem="340" firstAttribute="baseline" secondItem="339" secondAttribute="baseline" id="bEI-OX-62Q"/>
                                     <constraint firstItem="339" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="27" id="bbM-qQ-Svr"/>
                                     <constraint firstItem="340" firstAttribute="top" secondItem="337" secondAttribute="top" constant="14" id="blw-xd-2WF"/>
                                     <constraint firstItem="eRv-wi-Jsp" firstAttribute="baseline" secondItem="339" secondAttribute="baseline" id="cKH-um-2OR"/>
@@ -597,7 +597,7 @@
                                     <constraint firstItem="399" firstAttribute="leading" secondItem="395" secondAttribute="trailing" constant="3" id="oAe-6B-eNx"/>
                                     <constraint firstItem="397" firstAttribute="leading" secondItem="337" secondAttribute="leading" constant="26" id="rTN-X7-ef7"/>
                                     <constraint firstItem="97" firstAttribute="top" secondItem="96" secondAttribute="bottom" constant="10" symbolic="YES" id="ygR-RC-QCL"/>
-                                    <constraint firstItem="101" firstAttribute="firstBaseline" secondItem="97" secondAttribute="firstBaseline" id="zam-uF-El3"/>
+                                    <constraint firstItem="101" firstAttribute="baseline" secondItem="97" secondAttribute="baseline" id="zam-uF-El3"/>
                                     <constraint firstItem="101" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="337" secondAttribute="leading" constant="15" id="zlt-cT-xDN"/>
                                 </constraints>
                             </view>


### PR DESCRIPTION
For backward compatibility with macOS 10.10, the usage of first baseline auto layout attribute has been replaced with last baseline.

Closes #619 