### PR TITLE
Patch LibreSSL to use its own instead of system timingsafe_bcmp()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .idea/
 
 ThirdParty/Opus
-ThirdParty/LibreSSL
+ThirdParty/LibreSSL/*
+!ThirdParty/LibreSSL/patches
 ThirdParty/PJSIP/*
 !ThirdParty/PJSIP/patches

--- a/README.md
+++ b/README.md
@@ -24,11 +24,20 @@ Build and install:
 
 ### LibreSSL
 
+Download:
+
     $ curl -O https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.1.3.tar.gz
     $ curl -O https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.1.3.tar.gz.asc
     $ gpg --verify libressl-3.1.3.tar.gz.asc
     $ tar xzvf libressl-3.1.3.tar.gz
     $ cd libressl-3.1.3
+
+Patch:
+
+    $ patch -p0 -i /path/to/Telephone/ThirdParty/LibreSSL/patches/check-libc.patch
+
+Build and install:
+
     $ ./configure --prefix=/path/to/Telephone/ThirdParty/LibreSSL --disable-shared CFLAGS='-Os -mmacosx-version-min=10.10'
     $ make
     $ make install

--- a/ThirdParty/LibreSSL/patches/check-libc.patch
+++ b/ThirdParty/LibreSSL/patches/check-libc.patch
@@ -1,0 +1,13 @@
+diff --git m4/check-libc.m4 m4/check-libc.m4
+index e511f6d..d11493f 100644
+--- m4/check-libc.m4
++++ m4/check-libc.m4
+@@ -115,7 +115,7 @@ AC_CACHE_CHECK([for getentropy], ac_cv_func_getentropy, [
+ 	])
+ ])
+ 
+-AC_CHECK_FUNCS([timingsafe_bcmp timingsafe_memcmp])
++AC_CHECK_FUNCS([timingsafe_memcmp])
+ AM_CONDITIONAL([HAVE_ARC4RANDOM], [test "x$ac_cv_func_arc4random" = xyes])
+ AM_CONDITIONAL([HAVE_ARC4RANDOM_BUF], [test "x$ac_cv_func_arc4random_buf" = xyes])
+ AM_CONDITIONAL([HAVE_ARC4RANDOM_UNIFORM], [test "x$ac_cv_func_arc4random_uniform" = xyes])


### PR DESCRIPTION
Closes #618 