### PR TITLE
chore: add .env coverage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ ThirdParty/LibreSSL/*
 !ThirdParty/LibreSSL/patches
 ThirdParty/PJSIP/*
 !ThirdParty/PJSIP/patches
+
+# Environment files
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
Adds `.env` / `.env.*` (with `!.env.example` exception) to .gitignore so environment files with secrets cannot be committed by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)